### PR TITLE
Implement videoglancer issue #10

### DIFF
--- a/glancer/cli.py
+++ b/glancer/cli.py
@@ -6,27 +6,22 @@ import re
 import sys
 from pathlib import Path
 
-from .content import ExtractedContent
-from .slides import convert_to_html, convert_to_html_from_content
-from .pdf_builder import convert_to_pdf, convert_to_pdf_from_content
+from .content import ExtractedContent, extract_content
+from .image_similarity import find_similar_shots
 from .parser import parse_srt
+from .pdf_builder import convert_to_pdf, render_pdf_from_json
 from .playlist import Playlist
 from .process import cleanup_cache, delete_images, process_video
+from .slides import convert_to_html, get_caption_texts, render_html_from_json
 
 
-def _ensure_html_suffix(path: Path) -> Path:
-    return path.with_suffix(".html") if path.suffix.lower() != ".html" else path
-
-
-def _ensure_pdf_suffix(path: Path) -> Path:
-    return path.with_suffix(".pdf") if path.suffix.lower() != ".pdf" else path
-
-
-def _ensure_json_suffix(path: Path) -> Path:
-    return path.with_suffix(".json") if path.suffix.lower() != ".json" else path
+def _ensure_suffix(path: Path, suffix: str) -> Path:
+    """Ensure path has the specified suffix."""
+    return path.with_suffix(suffix) if path.suffix.lower() != suffix else path
 
 
 def _sanitize_filename(filename: str) -> str:
+    """Remove invalid filename characters."""
     return re.sub(r'[<>:"/\\|?*]', "_", filename)
 
 
@@ -42,57 +37,35 @@ def run(
     extract_json: bool = False,
     from_json: str | None = None,
 ) -> None:
+    """Main entry point."""
     ffmpeg_log_level = "info" if verbose else "error"
-
-    # Use current directory if no destination provided, we'll create a new file with the video name
     dest_path = Path(destination) if destination else Path.cwd()
 
-    # Phase 2 only: Generate artifact from existing JSON
+    # Phase 2: Generate from JSON
     if from_json:
-        generate_from_json(
-            from_json,
-            dest_path,
-            detect_duplicates,
-            output_pdf,
-            compact,
-            slide_mode,
-        )
+        generate_from_json(Path(from_json), dest_path, output_pdf, compact, slide_mode)
         return
 
-    # URL is required if not using --from-json
     if not url:
         raise ValueError("URL is required unless using --from-json")
 
+    # Handle playlists
     if Playlist.is_playlist(url):
         playlist = Playlist(url)
         print(f"Processing playlist: {url}", file=sys.stderr)
         for video_url in playlist:
-            process_and_save_video(
-                video_url,
-                dest_path,
-                ffmpeg_log_level,
-                auto_cleanup,
-                detect_duplicates,
-                output_pdf,
-                compact,
-                slide_mode,
-                extract_json,
+            process_single_video(
+                video_url, dest_path, ffmpeg_log_level, auto_cleanup,
+                detect_duplicates, output_pdf, compact, slide_mode, extract_json,
             )
     else:
-        process_and_save_video(
-            url,
-            dest_path,
-            ffmpeg_log_level,
-            auto_cleanup,
-            detect_duplicates,
-            output_pdf,
-            compact,
-            slide_mode,
-            extract_json,
+        process_single_video(
+            url, dest_path, ffmpeg_log_level, auto_cleanup,
+            detect_duplicates, output_pdf, compact, slide_mode, extract_json,
         )
 
 
-def process_and_save_video(
+def process_single_video(
     url: str,
     destination: Path,
     ffmpeg_log_level: str,
@@ -103,6 +76,7 @@ def process_and_save_video(
     slide_mode: bool,
     extract_json: bool = False,
 ) -> None:
+    """Process a single video."""
     dir_path, video, captions_path = process_video(url, ffmpeg_log_level)
     try:
         captions_text = captions_path.read_text(encoding="utf-8")
@@ -113,36 +87,29 @@ def process_and_save_video(
         else:
             output_path = destination
 
-        # Phase 1 only: Extract content to JSON and exit
         if extract_json:
-            content = ExtractedContent.from_processing(video, parsed, dir_path)
-            destination_path = _ensure_json_suffix(output_path.expanduser())
-            destination_path.parent.mkdir(parents=True, exist_ok=True)
-            print(f"Writing JSON to {destination_path}", file=sys.stderr)
-            content.save(destination_path)
-            return
-
-        # Full workflow or Phase 2: Generate artifact
-        if output_pdf:
-            destination_path = _ensure_pdf_suffix(output_path.expanduser())
-            destination_path.parent.mkdir(parents=True, exist_ok=True)
-            print(f"Writing PDF to {destination_path}", file=sys.stderr)
-            convert_to_pdf(
-                video,
-                dir_path,
-                parsed,
-                destination_path,
-                detect_duplicates,
-                compact,
-                slide_mode,
+            # Phase 1: Extract to JSON
+            caption_texts = get_caption_texts(parsed)
+            duplicates = find_similar_shots(dir_path.glob("glancer-img*.jpg")) if detect_duplicates else set()
+            content = extract_content(
+                video.url, video.title, video.video_id,
+                dir_path, caption_texts, duplicates,
             )
+            dest = _ensure_suffix(output_path.expanduser(), ".json")
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            print(f"Writing JSON to {dest}", file=sys.stderr)
+            content.save(dest)
+        elif output_pdf:
+            dest = _ensure_suffix(output_path.expanduser(), ".pdf")
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            print(f"Writing PDF to {dest}", file=sys.stderr)
+            convert_to_pdf(video, dir_path, parsed, dest, detect_duplicates, compact, slide_mode)
         else:
+            dest = _ensure_suffix(output_path.expanduser(), ".html")
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            print(f"Writing HTML to {dest}", file=sys.stderr)
             html = convert_to_html(video, dir_path, parsed, detect_duplicates)
-            destination_path = _ensure_html_suffix(output_path.expanduser())
-            destination_path.parent.mkdir(parents=True, exist_ok=True)
-            print(f"Writing HTML to {destination_path}", file=sys.stderr)
-            destination_path.write_text(html, encoding="utf-8")
-
+            dest.write_text(html, encoding="utf-8")
     finally:
         if auto_cleanup:
             cleanup_cache(dir_path)
@@ -151,133 +118,80 @@ def process_and_save_video(
 
 
 def generate_from_json(
-    json_path: str,
+    json_path: Path,
     destination: Path,
-    detect_duplicates: bool,
     output_pdf: bool,
     compact: bool,
     slide_mode: bool,
 ) -> None:
-    """Generate HTML or PDF output from previously extracted JSON content.
-
-    This is Phase 2 of the two-phase workflow, allowing artifact generation
-    without re-downloading or re-processing the video.
-    """
-    content = ExtractedContent.load(Path(json_path))
-    video = content.get_video()
-
-    print(f"Generating from extracted content: '{video.title}'", file=sys.stderr)
+    """Generate from JSON (Phase 2)."""
+    content = ExtractedContent.load(json_path)
+    print(f"Generating from: '{content.video.title}'", file=sys.stderr)
 
     if destination.is_dir():
-        output_path = destination / _sanitize_filename(video.title)
+        output_path = destination / _sanitize_filename(content.video.title)
     else:
         output_path = destination
 
     if output_pdf:
-        destination_path = _ensure_pdf_suffix(output_path.expanduser())
-        destination_path.parent.mkdir(parents=True, exist_ok=True)
-        print(f"Writing PDF to {destination_path}", file=sys.stderr)
-        convert_to_pdf_from_content(
-            content,
-            destination_path,
-            detect_duplicates,
-            compact,
-            slide_mode,
-        )
+        dest = _ensure_suffix(output_path.expanduser(), ".pdf")
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        print(f"Writing PDF to {dest}", file=sys.stderr)
+        render_pdf_from_json(content.video.url, content.video.title, content.slides, dest, compact, slide_mode)
     else:
-        html = convert_to_html_from_content(content, detect_duplicates)
-        destination_path = _ensure_html_suffix(output_path.expanduser())
-        destination_path.parent.mkdir(parents=True, exist_ok=True)
-        print(f"Writing HTML to {destination_path}", file=sys.stderr)
-        destination_path.write_text(html, encoding="utf-8")
+        dest = _ensure_suffix(output_path.expanduser(), ".html")
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        print(f"Writing HTML to {dest}", file=sys.stderr)
+        html = render_html_from_json(content.video.url, content.video.title, content.slides)
+        dest.write_text(html, encoding="utf-8")
 
 
 def main(argv: list[str] | None = None) -> None:
+    """CLI entry point."""
     logging.basicConfig(
         level=logging.WARNING, format="%(levelname)s: %(message)s", stream=sys.stderr
     )
 
     parser = argparse.ArgumentParser(prog="glancer", description="Glancer")
     parser.add_argument(
-        "url",
-        nargs="?",
-        default=None,
+        "url", nargs="?", default=None,
         help="YouTube URL or playlist URL (not required with --from-json)",
     )
     parser.add_argument(
-        "destination",
-        nargs="?",
-        default=None,
-        help="Output file name or directory (default: current directory with video title)",
+        "destination", nargs="?", default=None,
+        help="Output file or directory (default: current directory)",
     )
-    parser.add_argument(
-        "--verbose",
-        action="store_true",
-        help="Enable debug logging and show verbose ffmpeg logs",
-    )
-    parser.add_argument(
-        "--auto-cleanup",
-        action="store_true",
-        help="Delete cached downloads after HTML generation",
-    )
-    parser.add_argument(
-        "--no-detect-duplicates",
-        action="store_true",
-        help="Disable duplicate slide detection",
-    )
-    parser.add_argument(
-        "--pdf",
-        action="store_true",
-        help="Output as PDF instead of HTML (requires typst CLI)",
-    )
-    parser.add_argument(
-        "--compact-experimental",
-        action="store_true",
-        help="Use compact side-by-side layout for PDF (experimental)",
-    )
-    parser.add_argument(
-        "--slide-experimental",
-        action="store_true",
-        help="One slide per page for easy arrow-key navigation (experimental)",
-    )
-    parser.add_argument(
-        "--extract-json",
-        action="store_true",
-        help="Extract content to JSON instead of generating HTML/PDF (Phase 1)",
-    )
-    parser.add_argument(
-        "--from-json",
-        metavar="PATH",
-        help="Generate HTML/PDF from previously extracted JSON file (Phase 2)",
-    )
+    parser.add_argument("--verbose", action="store_true", help="Enable debug logging")
+    parser.add_argument("--auto-cleanup", action="store_true", help="Delete cached downloads")
+    parser.add_argument("--no-detect-duplicates", action="store_true", help="Disable duplicate detection")
+    parser.add_argument("--pdf", action="store_true", help="Output PDF (requires typst)")
+    parser.add_argument("--compact-experimental", action="store_true", help="Compact PDF layout")
+    parser.add_argument("--slide-experimental", action="store_true", help="One slide per page")
+    parser.add_argument("--extract-json", action="store_true", help="Extract to JSON (Phase 1)")
+    parser.add_argument("--from-json", metavar="PATH", help="Generate from JSON (Phase 2)")
     args = parser.parse_args(argv)
 
-    # Handle argument interpretation for --from-json mode
-    # When --from-json is provided, any positional argument is the destination (not URL)
+    # With --from-json, first positional arg is destination
     url = args.url
     destination = args.destination
     if args.from_json:
         if args.destination:
-            # Both positional args provided with --from-json is an error
             parser.error("Cannot specify URL with --from-json")
-        # With --from-json, first positional arg (url) is actually the destination
         destination = args.url
         url = None
 
-    # Validate arguments
     if not args.from_json and not url:
         parser.error("URL is required unless using --from-json")
     if args.extract_json and args.from_json:
         parser.error("Cannot use --extract-json with --from-json")
     if args.extract_json and args.pdf:
-        parser.error("Cannot use --extract-json with --pdf (JSON extraction doesn't generate PDF)")
+        parser.error("Cannot use --extract-json with --pdf")
 
-    log_level = logging.DEBUG if args.verbose else logging.WARNING
-    logging.getLogger().setLevel(log_level)
+    if args.verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
 
     run(
-        url,
-        destination,
+        url, destination,
         verbose=args.verbose,
         auto_cleanup=args.auto_cleanup,
         detect_duplicates=not args.no_detect_duplicates,

--- a/glancer/cli.py
+++ b/glancer/cli.py
@@ -6,8 +6,9 @@ import re
 import sys
 from pathlib import Path
 
-from .slides import convert_to_html
-from .pdf_builder import convert_to_pdf
+from .content import ExtractedContent
+from .slides import convert_to_html, convert_to_html_from_content
+from .pdf_builder import convert_to_pdf, convert_to_pdf_from_content
 from .parser import parse_srt
 from .playlist import Playlist
 from .process import cleanup_cache, delete_images, process_video
@@ -21,12 +22,16 @@ def _ensure_pdf_suffix(path: Path) -> Path:
     return path.with_suffix(".pdf") if path.suffix.lower() != ".pdf" else path
 
 
+def _ensure_json_suffix(path: Path) -> Path:
+    return path.with_suffix(".json") if path.suffix.lower() != ".json" else path
+
+
 def _sanitize_filename(filename: str) -> str:
     return re.sub(r'[<>:"/\\|?*]', "_", filename)
 
 
 def run(
-    url: str,
+    url: str | None,
     destination: str | None,
     verbose: bool,
     auto_cleanup: bool,
@@ -34,11 +39,29 @@ def run(
     output_pdf: bool,
     compact: bool,
     slide_mode: bool,
+    extract_json: bool = False,
+    from_json: str | None = None,
 ) -> None:
     ffmpeg_log_level = "info" if verbose else "error"
 
     # Use current directory if no destination provided, we'll create a new file with the video name
     dest_path = Path(destination) if destination else Path.cwd()
+
+    # Phase 2 only: Generate artifact from existing JSON
+    if from_json:
+        generate_from_json(
+            from_json,
+            dest_path,
+            detect_duplicates,
+            output_pdf,
+            compact,
+            slide_mode,
+        )
+        return
+
+    # URL is required if not using --from-json
+    if not url:
+        raise ValueError("URL is required unless using --from-json")
 
     if Playlist.is_playlist(url):
         playlist = Playlist(url)
@@ -53,6 +76,7 @@ def run(
                 output_pdf,
                 compact,
                 slide_mode,
+                extract_json,
             )
     else:
         process_and_save_video(
@@ -64,6 +88,7 @@ def run(
             output_pdf,
             compact,
             slide_mode,
+            extract_json,
         )
 
 
@@ -76,6 +101,7 @@ def process_and_save_video(
     output_pdf: bool,
     compact: bool,
     slide_mode: bool,
+    extract_json: bool = False,
 ) -> None:
     dir_path, video, captions_path = process_video(url, ffmpeg_log_level)
     try:
@@ -87,6 +113,16 @@ def process_and_save_video(
         else:
             output_path = destination
 
+        # Phase 1 only: Extract content to JSON and exit
+        if extract_json:
+            content = ExtractedContent.from_processing(video, parsed, dir_path)
+            destination_path = _ensure_json_suffix(output_path.expanduser())
+            destination_path.parent.mkdir(parents=True, exist_ok=True)
+            print(f"Writing JSON to {destination_path}", file=sys.stderr)
+            content.save(destination_path)
+            return
+
+        # Full workflow or Phase 2: Generate artifact
         if output_pdf:
             destination_path = _ensure_pdf_suffix(output_path.expanduser())
             destination_path.parent.mkdir(parents=True, exist_ok=True)
@@ -114,18 +150,65 @@ def process_and_save_video(
             delete_images(dir_path)
 
 
+def generate_from_json(
+    json_path: str,
+    destination: Path,
+    detect_duplicates: bool,
+    output_pdf: bool,
+    compact: bool,
+    slide_mode: bool,
+) -> None:
+    """Generate HTML or PDF output from previously extracted JSON content.
+
+    This is Phase 2 of the two-phase workflow, allowing artifact generation
+    without re-downloading or re-processing the video.
+    """
+    content = ExtractedContent.load(Path(json_path))
+    video = content.get_video()
+
+    print(f"Generating from extracted content: '{video.title}'", file=sys.stderr)
+
+    if destination.is_dir():
+        output_path = destination / _sanitize_filename(video.title)
+    else:
+        output_path = destination
+
+    if output_pdf:
+        destination_path = _ensure_pdf_suffix(output_path.expanduser())
+        destination_path.parent.mkdir(parents=True, exist_ok=True)
+        print(f"Writing PDF to {destination_path}", file=sys.stderr)
+        convert_to_pdf_from_content(
+            content,
+            destination_path,
+            detect_duplicates,
+            compact,
+            slide_mode,
+        )
+    else:
+        html = convert_to_html_from_content(content, detect_duplicates)
+        destination_path = _ensure_html_suffix(output_path.expanduser())
+        destination_path.parent.mkdir(parents=True, exist_ok=True)
+        print(f"Writing HTML to {destination_path}", file=sys.stderr)
+        destination_path.write_text(html, encoding="utf-8")
+
+
 def main(argv: list[str] | None = None) -> None:
     logging.basicConfig(
         level=logging.WARNING, format="%(levelname)s: %(message)s", stream=sys.stderr
     )
 
     parser = argparse.ArgumentParser(prog="glancer", description="Glancer")
-    parser.add_argument("url", help="YouTube URL or playlist URL")
+    parser.add_argument(
+        "url",
+        nargs="?",
+        default=None,
+        help="YouTube URL or playlist URL (not required with --from-json)",
+    )
     parser.add_argument(
         "destination",
         nargs="?",
         default=None,
-        help="HTML file name or directory (default: current directory with video title)",
+        help="Output file name or directory (default: current directory with video title)",
     )
     parser.add_argument(
         "--verbose",
@@ -157,20 +240,52 @@ def main(argv: list[str] | None = None) -> None:
         action="store_true",
         help="One slide per page for easy arrow-key navigation (experimental)",
     )
+    parser.add_argument(
+        "--extract-json",
+        action="store_true",
+        help="Extract content to JSON instead of generating HTML/PDF (Phase 1)",
+    )
+    parser.add_argument(
+        "--from-json",
+        metavar="PATH",
+        help="Generate HTML/PDF from previously extracted JSON file (Phase 2)",
+    )
     args = parser.parse_args(argv)
+
+    # Handle argument interpretation for --from-json mode
+    # When --from-json is provided, any positional argument is the destination (not URL)
+    url = args.url
+    destination = args.destination
+    if args.from_json:
+        if args.destination:
+            # Both positional args provided with --from-json is an error
+            parser.error("Cannot specify URL with --from-json")
+        # With --from-json, first positional arg (url) is actually the destination
+        destination = args.url
+        url = None
+
+    # Validate arguments
+    if not args.from_json and not url:
+        parser.error("URL is required unless using --from-json")
+    if args.extract_json and args.from_json:
+        parser.error("Cannot use --extract-json with --from-json")
+    if args.extract_json and args.pdf:
+        parser.error("Cannot use --extract-json with --pdf (JSON extraction doesn't generate PDF)")
 
     log_level = logging.DEBUG if args.verbose else logging.WARNING
     logging.getLogger().setLevel(log_level)
 
     run(
-        args.url,
-        args.destination,
+        url,
+        destination,
         verbose=args.verbose,
         auto_cleanup=args.auto_cleanup,
         detect_duplicates=not args.no_detect_duplicates,
         output_pdf=args.pdf,
         compact=args.compact_experimental,
         slide_mode=args.slide_experimental,
+        extract_json=args.extract_json,
+        from_json=args.from_json,
     )
 
 

--- a/glancer/content.py
+++ b/glancer/content.py
@@ -1,200 +1,198 @@
-"""Module for extracting and serializing video content to JSON.
+"""JSON Intermediate Representation for extracted video content.
 
-This module provides functionality to split the video processing workflow into two phases:
-1. Content Extraction: Download video, extract frames, parse captions, output JSON
-2. Artifact Generation: Read JSON, generate HTML/PDF output
+This module defines the JSON IR that bridges Phase 1 (extraction) and Phase 2 (rendering).
 
-The JSON intermediate format enables caching of the expensive extraction phase
-and allows experimentation with different output formats.
+## JSON IR Specification (v1)
+
+The JSON file contains all data needed to render HTML or PDF without re-processing:
+
+```json
+{
+  "schema_version": 1,
+  "video": {
+    "url": "https://youtube.com/watch?v=...",
+    "title": "Video Title",
+    "id": "video_id"
+  },
+  "slides": [
+    {
+      "index": 0,
+      "image_base64": "...",
+      "timestamp_seconds": 0,
+      "caption_text": "Combined caption text for this slide",
+      "is_duplicate": false
+    },
+    ...
+  ],
+  "config": {
+    "seconds_per_shot": 30
+  }
+}
+```
+
+### Fields:
+- schema_version: Integer version for compatibility checking
+- video: Source video metadata
+- slides: Pre-processed slides ready for rendering
+  - index: Slide number (0-based)
+  - image_base64: JPEG image encoded as base64 string
+  - timestamp_seconds: Video timestamp for this slide
+  - caption_text: Combined, cleaned caption text (empty string if none)
+  - is_duplicate: True if slide is visually similar to an earlier slide
+- config: Processing parameters used during extraction
 """
 from __future__ import annotations
 
 import base64
 import json
 import logging
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from .parser import Caption
-from .process import Video
-
 logger = logging.getLogger(__name__)
 
-# Schema version for backwards compatibility
-CONTENT_SCHEMA_VERSION = 1
+SCHEMA_VERSION = 1
 
 
-@dataclass
-class ExtractedImage:
-    """A single extracted frame from the video."""
+@dataclass(frozen=True)
+class VideoInfo:
+    """Video metadata."""
+    url: str
+    title: str
+    id: str
 
-    index: int  # Frame index (0-based)
-    data_base64: str  # Base64-encoded JPEG data
-    timestamp_seconds: int  # Timestamp in seconds when this frame was captured
+
+@dataclass(frozen=True)
+class SlideData:
+    """A single slide ready for rendering."""
+    index: int
+    image_base64: str
+    timestamp_seconds: int
+    caption_text: str
+    is_duplicate: bool
 
 
 @dataclass
 class ExtractedContent:
-    """Complete extracted content from a video, serializable to JSON.
+    """Complete extracted content, serializable to JSON."""
+    video: VideoInfo
+    slides: list[SlideData]
+    seconds_per_shot: int = 30
 
-    This structure contains all data needed to generate HTML or PDF output
-    without requiring access to the original video or intermediate files.
-    """
-
-    # Schema version for forward/backward compatibility
-    schema_version: int
-
-    # Video metadata
-    video_url: str
-    video_title: str
-    video_id: str
-
-    # Captions list
-    captions: list[dict[str, Any]]  # List of {start, end, text}
-
-    # Extracted images
-    images: list[dict[str, Any]]  # List of {index, data_base64, timestamp_seconds}
-
-    # Processing configuration
-    seconds_per_shot: int
-
-    @classmethod
-    def from_processing(
-        cls,
-        video: Video,
-        captions: list[Caption],
-        directory: Path,
-        seconds_per_shot: int = 30,
-    ) -> "ExtractedContent":
-        """Create ExtractedContent from video processing results.
-
-        Args:
-            video: Video metadata
-            captions: Parsed captions from SRT
-            directory: Directory containing extracted JPEG frames
-            seconds_per_shot: Seconds between each frame (default 30)
-
-        Returns:
-            ExtractedContent ready for serialization
-        """
-        # Convert captions to dict format
-        caption_dicts = [
-            {"start": c.start, "end": c.end, "text": c.text} for c in captions
-        ]
-
-        # Load and encode images
-        images: list[dict[str, Any]] = []
-        for img_path in sorted(directory.glob("glancer-img*.jpg")):
-            try:
-                # Extract index from filename (glancer-img0001.jpg -> 1)
-                index = int(img_path.stem.replace("glancer-img", ""))
-                data = img_path.read_bytes()
-                data_base64 = base64.b64encode(data).decode("ascii")
-                images.append(
-                    {
-                        "index": index,
-                        "data_base64": data_base64,
-                        "timestamp_seconds": index * seconds_per_shot,
-                    }
-                )
-            except (ValueError, OSError) as e:
-                logger.warning(f"Failed to process image {img_path}: {e}")
-                continue
-
-        logger.info(f"Extracted {len(images)} images and {len(caption_dicts)} captions")
-
-        return cls(
-            schema_version=CONTENT_SCHEMA_VERSION,
-            video_url=video.url,
-            video_title=video.title,
-            video_id=video.video_id,
-            captions=caption_dicts,
-            images=images,
-            seconds_per_shot=seconds_per_shot,
-        )
-
-    def to_json(self, indent: int | None = 2) -> str:
-        """Serialize to JSON string.
-
-        Args:
-            indent: JSON indentation level (None for compact)
-
-        Returns:
-            JSON string representation
-        """
-        return json.dumps(asdict(self), indent=indent)
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to JSON-serializable dict."""
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "video": {
+                "url": self.video.url,
+                "title": self.video.title,
+                "id": self.video.id,
+            },
+            "slides": [
+                {
+                    "index": s.index,
+                    "image_base64": s.image_base64,
+                    "timestamp_seconds": s.timestamp_seconds,
+                    "caption_text": s.caption_text,
+                    "is_duplicate": s.is_duplicate,
+                }
+                for s in self.slides
+            ],
+            "config": {
+                "seconds_per_shot": self.seconds_per_shot,
+            },
+        }
 
     def save(self, path: Path) -> None:
-        """Save to a JSON file.
-
-        Args:
-            path: Output file path
-        """
-        path.write_text(self.to_json(), encoding="utf-8")
-        logger.info(f"Saved extracted content to {path}")
+        """Save to JSON file."""
+        path.write_text(json.dumps(self.to_dict(), indent=2), encoding="utf-8")
 
     @classmethod
     def load(cls, path: Path) -> "ExtractedContent":
-        """Load from a JSON file.
-
-        Args:
-            path: Input file path
-
-        Returns:
-            ExtractedContent instance
-
-        Raises:
-            ValueError: If schema version is unsupported
-        """
+        """Load from JSON file."""
         data = json.loads(path.read_text(encoding="utf-8"))
 
-        schema_version = data.get("schema_version", 1)
-        if schema_version > CONTENT_SCHEMA_VERSION:
+        version = data.get("schema_version", 1)
+        if version > SCHEMA_VERSION:
             raise ValueError(
-                f"Unsupported schema version {schema_version}. "
-                f"Maximum supported version is {CONTENT_SCHEMA_VERSION}"
+                f"JSON schema version {version} not supported. "
+                f"Maximum supported: {SCHEMA_VERSION}"
             )
 
-        return cls(
-            schema_version=schema_version,
-            video_url=data["video_url"],
-            video_title=data["video_title"],
-            video_id=data["video_id"],
-            captions=data["captions"],
-            images=data["images"],
-            seconds_per_shot=data.get("seconds_per_shot", 30),
+        video = VideoInfo(
+            url=data["video"]["url"],
+            title=data["video"]["title"],
+            id=data["video"]["id"],
         )
 
-    def get_video(self) -> Video:
-        """Reconstruct Video object from extracted content."""
-        return Video(
-            url=self.video_url,
-            title=self.video_title,
-            video_id=self.video_id,
-        )
-
-    def get_captions(self) -> list[Caption]:
-        """Reconstruct Caption objects from extracted content."""
-        return [
-            Caption(start=c["start"], end=c["end"], text=c["text"])
-            for c in self.captions
+        slides = [
+            SlideData(
+                index=s["index"],
+                image_base64=s["image_base64"],
+                timestamp_seconds=s["timestamp_seconds"],
+                caption_text=s["caption_text"],
+                is_duplicate=s["is_duplicate"],
+            )
+            for s in data["slides"]
         ]
 
-    def get_image_data(self, index: int) -> bytes | None:
-        """Get decoded image data for a specific index.
+        return cls(
+            video=video,
+            slides=slides,
+            seconds_per_shot=data.get("config", {}).get("seconds_per_shot", 30),
+        )
 
-        Args:
-            index: Frame index
 
-        Returns:
-            Decoded JPEG bytes or None if not found
-        """
-        for img in self.images:
-            if img["index"] == index:
-                return base64.b64decode(img["data_base64"])
-        return None
+def extract_content(
+    video_url: str,
+    video_title: str,
+    video_id: str,
+    image_dir: Path,
+    caption_texts: list[str],
+    duplicate_indices: set[int],
+    seconds_per_shot: int = 30,
+) -> ExtractedContent:
+    """Create ExtractedContent from processing results.
 
-    def get_image_indices(self) -> list[int]:
-        """Get sorted list of available image indices."""
-        return sorted(img["index"] for img in self.images)
+    Args:
+        video_url: Source video URL
+        video_title: Video title
+        video_id: Video ID
+        image_dir: Directory containing glancer-img*.jpg files
+        caption_texts: List of caption text per slide (index-aligned)
+        duplicate_indices: Set of slide indices that are duplicates
+        seconds_per_shot: Seconds between each frame
+
+    Returns:
+        ExtractedContent ready for serialization
+    """
+    video = VideoInfo(url=video_url, title=video_title, id=video_id)
+    slides: list[SlideData] = []
+
+    # Load images and create slides
+    for img_path in sorted(image_dir.glob("glancer-img*.jpg")):
+        try:
+            index = int(img_path.stem.replace("glancer-img", ""))
+        except ValueError:
+            continue
+
+        try:
+            image_data = base64.b64encode(img_path.read_bytes()).decode("ascii")
+        except OSError as e:
+            logger.warning(f"Failed to read image {img_path}: {e}")
+            continue
+
+        caption_text = caption_texts[index] if index < len(caption_texts) else ""
+
+        slides.append(
+            SlideData(
+                index=index,
+                image_base64=image_data,
+                timestamp_seconds=index * seconds_per_shot,
+                caption_text=caption_text,
+                is_duplicate=index in duplicate_indices,
+            )
+        )
+
+    return ExtractedContent(video=video, slides=slides, seconds_per_shot=seconds_per_shot)

--- a/glancer/content.py
+++ b/glancer/content.py
@@ -1,0 +1,200 @@
+"""Module for extracting and serializing video content to JSON.
+
+This module provides functionality to split the video processing workflow into two phases:
+1. Content Extraction: Download video, extract frames, parse captions, output JSON
+2. Artifact Generation: Read JSON, generate HTML/PDF output
+
+The JSON intermediate format enables caching of the expensive extraction phase
+and allows experimentation with different output formats.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from .parser import Caption
+from .process import Video
+
+logger = logging.getLogger(__name__)
+
+# Schema version for backwards compatibility
+CONTENT_SCHEMA_VERSION = 1
+
+
+@dataclass
+class ExtractedImage:
+    """A single extracted frame from the video."""
+
+    index: int  # Frame index (0-based)
+    data_base64: str  # Base64-encoded JPEG data
+    timestamp_seconds: int  # Timestamp in seconds when this frame was captured
+
+
+@dataclass
+class ExtractedContent:
+    """Complete extracted content from a video, serializable to JSON.
+
+    This structure contains all data needed to generate HTML or PDF output
+    without requiring access to the original video or intermediate files.
+    """
+
+    # Schema version for forward/backward compatibility
+    schema_version: int
+
+    # Video metadata
+    video_url: str
+    video_title: str
+    video_id: str
+
+    # Captions list
+    captions: list[dict[str, Any]]  # List of {start, end, text}
+
+    # Extracted images
+    images: list[dict[str, Any]]  # List of {index, data_base64, timestamp_seconds}
+
+    # Processing configuration
+    seconds_per_shot: int
+
+    @classmethod
+    def from_processing(
+        cls,
+        video: Video,
+        captions: list[Caption],
+        directory: Path,
+        seconds_per_shot: int = 30,
+    ) -> "ExtractedContent":
+        """Create ExtractedContent from video processing results.
+
+        Args:
+            video: Video metadata
+            captions: Parsed captions from SRT
+            directory: Directory containing extracted JPEG frames
+            seconds_per_shot: Seconds between each frame (default 30)
+
+        Returns:
+            ExtractedContent ready for serialization
+        """
+        # Convert captions to dict format
+        caption_dicts = [
+            {"start": c.start, "end": c.end, "text": c.text} for c in captions
+        ]
+
+        # Load and encode images
+        images: list[dict[str, Any]] = []
+        for img_path in sorted(directory.glob("glancer-img*.jpg")):
+            try:
+                # Extract index from filename (glancer-img0001.jpg -> 1)
+                index = int(img_path.stem.replace("glancer-img", ""))
+                data = img_path.read_bytes()
+                data_base64 = base64.b64encode(data).decode("ascii")
+                images.append(
+                    {
+                        "index": index,
+                        "data_base64": data_base64,
+                        "timestamp_seconds": index * seconds_per_shot,
+                    }
+                )
+            except (ValueError, OSError) as e:
+                logger.warning(f"Failed to process image {img_path}: {e}")
+                continue
+
+        logger.info(f"Extracted {len(images)} images and {len(caption_dicts)} captions")
+
+        return cls(
+            schema_version=CONTENT_SCHEMA_VERSION,
+            video_url=video.url,
+            video_title=video.title,
+            video_id=video.video_id,
+            captions=caption_dicts,
+            images=images,
+            seconds_per_shot=seconds_per_shot,
+        )
+
+    def to_json(self, indent: int | None = 2) -> str:
+        """Serialize to JSON string.
+
+        Args:
+            indent: JSON indentation level (None for compact)
+
+        Returns:
+            JSON string representation
+        """
+        return json.dumps(asdict(self), indent=indent)
+
+    def save(self, path: Path) -> None:
+        """Save to a JSON file.
+
+        Args:
+            path: Output file path
+        """
+        path.write_text(self.to_json(), encoding="utf-8")
+        logger.info(f"Saved extracted content to {path}")
+
+    @classmethod
+    def load(cls, path: Path) -> "ExtractedContent":
+        """Load from a JSON file.
+
+        Args:
+            path: Input file path
+
+        Returns:
+            ExtractedContent instance
+
+        Raises:
+            ValueError: If schema version is unsupported
+        """
+        data = json.loads(path.read_text(encoding="utf-8"))
+
+        schema_version = data.get("schema_version", 1)
+        if schema_version > CONTENT_SCHEMA_VERSION:
+            raise ValueError(
+                f"Unsupported schema version {schema_version}. "
+                f"Maximum supported version is {CONTENT_SCHEMA_VERSION}"
+            )
+
+        return cls(
+            schema_version=schema_version,
+            video_url=data["video_url"],
+            video_title=data["video_title"],
+            video_id=data["video_id"],
+            captions=data["captions"],
+            images=data["images"],
+            seconds_per_shot=data.get("seconds_per_shot", 30),
+        )
+
+    def get_video(self) -> Video:
+        """Reconstruct Video object from extracted content."""
+        return Video(
+            url=self.video_url,
+            title=self.video_title,
+            video_id=self.video_id,
+        )
+
+    def get_captions(self) -> list[Caption]:
+        """Reconstruct Caption objects from extracted content."""
+        return [
+            Caption(start=c["start"], end=c["end"], text=c["text"])
+            for c in self.captions
+        ]
+
+    def get_image_data(self, index: int) -> bytes | None:
+        """Get decoded image data for a specific index.
+
+        Args:
+            index: Frame index
+
+        Returns:
+            Decoded JPEG bytes or None if not found
+        """
+        for img in self.images:
+            if img["index"] == index:
+                return base64.b64decode(img["data_base64"])
+        return None
+
+    def get_image_indices(self) -> list[int]:
+        """Get sorted list of available image indices."""
+        return sorted(img["index"] for img in self.images)

--- a/glancer/extract.py
+++ b/glancer/extract.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""glancer-extract: Extract video content to JSON.
+
+This tool downloads a YouTube video, extracts frames and captions,
+and outputs a self-contained JSON file for later rendering.
+
+Usage:
+    glancer-extract URL [OUTPUT]
+    glancer-extract https://youtube.com/watch?v=... output.json
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import html
+import logging
+import math
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Iterable, Sequence
+
+import srt
+from PIL import Image, ImageOps
+
+from .schema import ExtractedContent, SlideData, VideoMeta
+
+logger = logging.getLogger(__name__)
+
+SECONDS_PER_SHOT = 30
+CHUNK_SECONDS = 300
+JPEG_QUALITY = "5"
+
+
+# === Video download ===
+
+
+@dataclass(frozen=True)
+class Video:
+    url: str
+    title: str
+    video_id: str
+
+
+def download_video(url: str, ffmpeg_log_level: str = "error") -> tuple[Path, Video, Path]:
+    """Download video and captions, extract frames."""
+    video = _get_video_metadata(url)
+    print(f"Processing: '{video.title}'", file=sys.stderr)
+
+    cache_dir = Path(tempfile.gettempdir()) / "glancer" / video.video_id
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    captions_path = _download_video_and_captions(video, cache_dir)
+    _extract_frames(cache_dir, video.video_id, ffmpeg_log_level)
+
+    return cache_dir, video, captions_path
+
+
+def _get_video_metadata(url: str) -> Video:
+    title = subprocess.run(
+        ["yt-dlp", "-e", "--no-warnings", "--no-playlist", url],
+        check=True, capture_output=True, text=True,
+    ).stdout.strip()
+
+    video_id = subprocess.run(
+        ["yt-dlp", "--get-id", "--no-warnings", "--no-playlist", url],
+        check=True, capture_output=True, text=True,
+    ).stdout.strip()
+
+    return Video(url=url, title=title, video_id=video_id)
+
+
+def _download_video_and_captions(video: Video, cache_dir: Path) -> Path:
+    video_path = cache_dir / f"{video.video_id}.mp4"
+    captions_path = cache_dir / f"{video.video_id}.en.srt"
+
+    if video_path.exists() and captions_path.exists():
+        print(f"Using cached video in {cache_dir}", file=sys.stderr)
+        return captions_path
+
+    print("Downloading video...", file=sys.stderr)
+    subprocess.run([
+        "yt-dlp", "-q", "--no-playlist",
+        "-f", "bv*[height<=720][ext=mp4]+ba[ext=m4a]/b[height<=720][ext=mp4]/best[ext=mp4]",
+        "-o", str(cache_dir / f"{video.video_id}.%(ext)s"),
+        "--merge-output-format", "mp4",
+        "--sub-langs", "en", "--write-auto-sub", "--write-sub",
+        "--sub-format", "srt", "--no-warnings", "-k", "--no-cache-dir",
+        video.url,
+    ], check=True, capture_output=True, text=True)
+
+    return captions_path
+
+
+def _extract_frames(cache_dir: Path, video_id: str, log_level: str) -> None:
+    print("Extracting frames...", file=sys.stderr)
+    video_path = cache_dir / f"{video_id}.mp4"
+
+    duration = int(float(subprocess.run(
+        ["ffprobe", "-v", "error", "-show_entries", "format=duration",
+         "-of", "default=noprint_wrappers=1:nokey=1", str(video_path)],
+        check=True, capture_output=True, text=True,
+    ).stdout.strip() or "0"))
+
+    starts = [0] if duration <= 0 else list(range(0, duration, max(CHUNK_SECONDS, SECONDS_PER_SHOT)))
+    tasks = []
+
+    for start in starts:
+        length = max(0, min(CHUNK_SECONDS, duration - start))
+        if length <= 0:
+            continue
+        start_number = int(math.floor(start / SECONDS_PER_SHOT))
+        tasks.append(_build_ffmpeg_cmd(cache_dir, video_id, start, length, start_number, log_level))
+
+    if tasks:
+        with ThreadPoolExecutor(max_workers=max(1, min(len(tasks), (os.cpu_count() or 1) * 2))) as ex:
+            ex.map(_run_ffmpeg, tasks)
+
+    # First frame at 3 seconds
+    _run_ffmpeg([
+        "ffmpeg", "-y", "-hide_banner", "-loglevel", log_level,
+        "-ss", "3", "-i", str(video_path),
+        "-pix_fmt", "yuvj420p", "-q:v", JPEG_QUALITY, "-vframes", "1",
+        str(cache_dir / "glancer-img0000.jpg"),
+    ])
+
+
+def _build_ffmpeg_cmd(cache_dir: Path, video_id: str, start: int, length: int, start_number: int, log_level: str) -> list[str]:
+    return [
+        "ffmpeg", "-y", "-hide_banner", "-loglevel", log_level,
+        "-ss", str(start), "-t", str(length),
+        "-i", str(cache_dir / f"{video_id}.mp4"),
+        "-vf", "fps=1/30", "-pix_fmt", "yuvj420p", "-q:v", JPEG_QUALITY,
+        "-start_number", str(start_number),
+        str(cache_dir / "glancer-img%04d.jpg"),
+    ]
+
+
+def _run_ffmpeg(cmd: list[str]) -> None:
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        logger.warning(f"ffmpeg error: {result.stderr}")
+
+
+# === Caption processing ===
+
+
+@dataclass(frozen=True)
+class Caption:
+    start: float
+    end: float
+    text: str
+
+
+def parse_captions(path: Path) -> list[Caption]:
+    """Parse SRT file into Caption objects."""
+    contents = path.read_text(encoding="utf-8")
+    return [
+        Caption(
+            start=sub.start.total_seconds(),
+            end=sub.end.total_seconds(),
+            text=sub.content.replace("\r\n", "\n").replace("\r", "\n"),
+        )
+        for sub in srt.parse(contents)
+    ]
+
+
+def get_caption_texts(captions: list[Caption]) -> list[str]:
+    """Get combined caption text for each slide."""
+    cleaned = [_clean_caption(c) for c in captions if _clean_caption(c).text]
+    if not cleaned:
+        return []
+
+    total_shots = max(1, int(math.floor(cleaned[-1].end / SECONDS_PER_SHOT)))
+    texts = []
+
+    for shot_idx in range(total_shots):
+        shot_start = shot_idx * SECONDS_PER_SHOT
+        shot_end = cleaned[-1].end if shot_idx == total_shots - 1 else shot_start + SECONDS_PER_SHOT
+
+        overlapping = [c for c in cleaned if c.start <= shot_end and c.end >= shot_start]
+        combined = " ".join(" ".join(c.text.strip().replace("\n", " ").split()) for c in overlapping)
+        texts.append(" ".join(combined.split()))
+
+    return texts
+
+
+TAG_RE = re.compile(r"<[^>]+>")
+
+
+def _clean_caption(caption: Caption) -> Caption:
+    text = html.unescape(caption.text)
+    text = TAG_RE.sub("", text)
+    text = text.replace("\u00a0", " ").strip()
+    return replace(caption, text=text)
+
+
+# === Duplicate detection ===
+
+
+def find_duplicates(image_dir: Path, threshold: int = 5) -> set[int]:
+    """Find duplicate slides using perceptual hashing."""
+    duplicates: set[int] = set()
+    unique_hashes: list[int] = []
+
+    for path in sorted(image_dir.glob("glancer-img*.jpg")):
+        try:
+            idx = int(path.stem.replace("glancer-img", ""))
+            img_hash = _dhash(path)
+        except (ValueError, OSError):
+            continue
+
+        if any(_hamming(img_hash, h) <= threshold for h in unique_hashes):
+            duplicates.add(idx)
+        else:
+            unique_hashes.append(img_hash)
+
+    return duplicates
+
+
+def _dhash(path: Path, size: int = 8) -> int:
+    with Image.open(path) as img:
+        gray = ImageOps.grayscale(img)
+        resized = gray.resize((size + 1, size), getattr(Image.Resampling, "LANCZOS", Image.LANCZOS))
+        pixels = list(resized.getdata())
+
+    bits = []
+    for row in range(size):
+        offset = row * (size + 1)
+        for col in range(size):
+            bits.append(1 if pixels[offset + col] < pixels[offset + col + 1] else 0)
+
+    result = 0
+    for i, bit in enumerate(bits):
+        if bit:
+            result |= 1 << i
+    return result
+
+
+def _hamming(a: int, b: int) -> int:
+    return (a ^ b).bit_count()
+
+
+# === Content extraction ===
+
+
+def extract(video: Video, image_dir: Path, caption_texts: list[str], duplicates: set[int]) -> ExtractedContent:
+    """Create ExtractedContent from processed video data."""
+    slides: list[SlideData] = []
+
+    for img_path in sorted(image_dir.glob("glancer-img*.jpg")):
+        try:
+            idx = int(img_path.stem.replace("glancer-img", ""))
+            img_b64 = base64.b64encode(img_path.read_bytes()).decode("ascii")
+        except (ValueError, OSError):
+            continue
+
+        slides.append(SlideData(
+            index=idx,
+            image_base64=img_b64,
+            timestamp_seconds=idx * SECONDS_PER_SHOT,
+            caption_text=caption_texts[idx] if idx < len(caption_texts) else "",
+            is_duplicate=idx in duplicates,
+        ))
+
+    return ExtractedContent(
+        video=VideoMeta(url=video.url, title=video.title, id=video.video_id),
+        slides=slides,
+        seconds_per_shot=SECONDS_PER_SHOT,
+    )
+
+
+# === CLI ===
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        prog="glancer-extract",
+        description="Extract YouTube video content to JSON",
+    )
+    parser.add_argument("url", help="YouTube video URL")
+    parser.add_argument("output", nargs="?", help="Output JSON file (default: VIDEO_TITLE.json)")
+    parser.add_argument("--verbose", "-v", action="store_true", help="Verbose output")
+    parser.add_argument("--no-detect-duplicates", action="store_true", help="Skip duplicate detection")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.WARNING,
+        format="%(levelname)s: %(message)s",
+        stream=sys.stderr,
+    )
+
+    # Download and process
+    cache_dir, video, captions_path = download_video(
+        args.url,
+        ffmpeg_log_level="info" if args.verbose else "error",
+    )
+
+    # Parse captions
+    captions = parse_captions(captions_path)
+    caption_texts = get_caption_texts(captions)
+
+    # Detect duplicates
+    duplicates = set() if args.no_detect_duplicates else find_duplicates(cache_dir)
+
+    # Extract content
+    content = extract(video, cache_dir, caption_texts, duplicates)
+
+    # Output
+    if args.output:
+        output_path = Path(args.output)
+    else:
+        safe_title = re.sub(r'[<>:"/\\|?*]', '_', video.title)
+        output_path = Path(f"{safe_title}.json")
+    content.save(output_path)
+    print(f"Saved: {output_path}", file=sys.stderr)
+    print(f"  {len(content.slides)} slides, {len([s for s in content.slides if not s.is_duplicate])} unique", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/glancer/image_similarity.py
+++ b/glancer/image_similarity.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import base64
+import io
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, Sequence
@@ -87,3 +89,66 @@ def _dhash(path: Path, hash_size: int) -> int:
 
 def _hamming_distance(left: int, right: int) -> int:
     return (left ^ right).bit_count()
+
+
+def find_similar_shots_from_data(
+    image_data: dict[int, str],
+    config: ShotSimilarityConfig | None = None,
+) -> set[int]:
+    """Return shot indexes whose imagery matches earlier shots, using base64 data.
+
+    This function works with pre-extracted image data from JSON, avoiding
+    the need to read images from disk.
+
+    Args:
+        image_data: Dict mapping shot index to base64-encoded JPEG data
+        config: Similarity detection configuration
+
+    Returns:
+        Set of shot indices that are duplicates of earlier shots
+    """
+    cfg = config or ShotSimilarityConfig()
+    duplicates: set[int] = set()
+    unique_hashes: list[int] = []
+
+    for shot_index in sorted(image_data.keys()):
+        try:
+            shot_hash = _dhash_from_data(image_data[shot_index], cfg.hash_size)
+        except OSError:
+            # Ignore images Pillow cannot handle; we leave the slide as non-duplicate.
+            continue
+
+        if _is_duplicate(shot_hash, unique_hashes, cfg.threshold):
+            duplicates.add(shot_index)
+        else:
+            unique_hashes.append(shot_hash)
+
+    return duplicates
+
+
+def _dhash_from_data(data_base64: str, hash_size: int) -> int:
+    """Compute a perceptual difference hash from base64-encoded image data."""
+    image_bytes = base64.b64decode(data_base64)
+    with Image.open(io.BytesIO(image_bytes)) as image:
+        grayscale = ImageOps.grayscale(image)
+        resized = grayscale.resize(
+            (hash_size + 1, hash_size),
+            getattr(Image.Resampling, "LANCZOS", Image.LANCZOS),
+        )
+        pixels = list(resized.getdata())
+
+    bits = []
+    row_stride = hash_size + 1
+    for row in range(hash_size):
+        offset = row * row_stride
+        row_pixels = pixels[offset : offset + row_stride]
+        for col in range(hash_size):
+            left = row_pixels[col]
+            right = row_pixels[col + 1]
+            bits.append(1 if left < right else 0)
+
+    result = 0
+    for bit_index, bit in enumerate(bits):
+        if bit:
+            result |= 1 << bit_index
+    return result

--- a/glancer/image_similarity.py
+++ b/glancer/image_similarity.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import base64
-import io
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, Sequence
@@ -89,66 +87,3 @@ def _dhash(path: Path, hash_size: int) -> int:
 
 def _hamming_distance(left: int, right: int) -> int:
     return (left ^ right).bit_count()
-
-
-def find_similar_shots_from_data(
-    image_data: dict[int, str],
-    config: ShotSimilarityConfig | None = None,
-) -> set[int]:
-    """Return shot indexes whose imagery matches earlier shots, using base64 data.
-
-    This function works with pre-extracted image data from JSON, avoiding
-    the need to read images from disk.
-
-    Args:
-        image_data: Dict mapping shot index to base64-encoded JPEG data
-        config: Similarity detection configuration
-
-    Returns:
-        Set of shot indices that are duplicates of earlier shots
-    """
-    cfg = config or ShotSimilarityConfig()
-    duplicates: set[int] = set()
-    unique_hashes: list[int] = []
-
-    for shot_index in sorted(image_data.keys()):
-        try:
-            shot_hash = _dhash_from_data(image_data[shot_index], cfg.hash_size)
-        except OSError:
-            # Ignore images Pillow cannot handle; we leave the slide as non-duplicate.
-            continue
-
-        if _is_duplicate(shot_hash, unique_hashes, cfg.threshold):
-            duplicates.add(shot_index)
-        else:
-            unique_hashes.append(shot_hash)
-
-    return duplicates
-
-
-def _dhash_from_data(data_base64: str, hash_size: int) -> int:
-    """Compute a perceptual difference hash from base64-encoded image data."""
-    image_bytes = base64.b64decode(data_base64)
-    with Image.open(io.BytesIO(image_bytes)) as image:
-        grayscale = ImageOps.grayscale(image)
-        resized = grayscale.resize(
-            (hash_size + 1, hash_size),
-            getattr(Image.Resampling, "LANCZOS", Image.LANCZOS),
-        )
-        pixels = list(resized.getdata())
-
-    bits = []
-    row_stride = hash_size + 1
-    for row in range(hash_size):
-        offset = row * row_stride
-        row_pixels = pixels[offset : offset + row_stride]
-        for col in range(hash_size):
-            left = row_pixels[col]
-            right = row_pixels[col + 1]
-            bits.append(1 if left < right else 0)
-
-    result = 0
-    for bit_index, bit in enumerate(bits):
-        if bit:
-            result |= 1 << bit_index
-    return result

--- a/glancer/pdf_builder.py
+++ b/glancer/pdf_builder.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
+import base64
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from .parser import Caption
 from .process import Video
-from .slides import Slide, generate_slides
+from .slides import Slide, generate_slides, generate_slides_from_content
+
+if TYPE_CHECKING:
+    from .content import ExtractedContent
 
 SECONDS_PER_SHOT = 30
 
@@ -33,6 +38,52 @@ def convert_to_pdf(
             if src_img.exists():
                 dst_img = tmp_path / f"img{slide.index:04d}.jpg"
                 shutil.copy(src_img, dst_img)
+
+        # Generate Typst content
+        typst_content = generate_typst(video, slides, tmp_path, compact, slide_mode)
+
+        # Write Typst file
+        typst_file = tmp_path / "output.typ"
+        typst_file.write_text(typst_content, encoding="utf-8")
+
+        # Compile to PDF
+        subprocess.run(
+            ["typst", "compile", str(typst_file), str(output_path)],
+            check=True,
+        )
+
+
+def convert_to_pdf_from_content(
+    content: "ExtractedContent",
+    output_path: Path,
+    detect_duplicates: bool = True,
+    compact: bool = False,
+    slide_mode: bool = False,
+) -> None:
+    """Generate a PDF from ExtractedContent (Phase 2 workflow).
+
+    This function works with pre-extracted content from JSON, avoiding
+    the need to re-download or re-process the video.
+    """
+    video = content.get_video()
+    captions = content.get_captions()
+
+    # Build image data lookup: index -> base64 data
+    image_data: dict[int, str] = {
+        img["index"]: img["data_base64"] for img in content.images
+    }
+
+    slides = generate_slides_from_content(captions, image_data, detect_duplicates)
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+
+        # Write images from base64 data to temp directory
+        for slide in slides:
+            if slide.index in image_data:
+                img_bytes = base64.b64decode(image_data[slide.index])
+                dst_img = tmp_path / f"img{slide.index:04d}.jpg"
+                dst_img.write_bytes(img_bytes)
 
         # Generate Typst content
         typst_content = generate_typst(video, slides, tmp_path, compact, slide_mode)

--- a/glancer/pdf_builder.py
+++ b/glancer/pdf_builder.py
@@ -9,12 +9,15 @@ from typing import TYPE_CHECKING
 
 from .parser import Caption
 from .process import Video
-from .slides import Slide, generate_slides, generate_slides_from_content
+from .slides import Slide, generate_slides
 
 if TYPE_CHECKING:
-    from .content import ExtractedContent
+    from .content import SlideData
 
 SECONDS_PER_SHOT = 30
+
+
+# === Phase 1: Generate PDF from video processing ===
 
 
 def convert_to_pdf(
@@ -26,7 +29,7 @@ def convert_to_pdf(
     compact: bool = False,
     slide_mode: bool = False,
 ) -> None:
-    """Generate a dense PDF from video slides using Typst."""
+    """Generate PDF from video processing results (Phase 1 or standalone)."""
     slides = generate_slides(captions, directory, detect_duplicates)
 
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -39,64 +42,81 @@ def convert_to_pdf(
                 dst_img = tmp_path / f"img{slide.index:04d}.jpg"
                 shutil.copy(src_img, dst_img)
 
-        # Generate Typst content
-        typst_content = generate_typst(video, slides, tmp_path, compact, slide_mode)
-
-        # Write Typst file
-        typst_file = tmp_path / "output.typ"
-        typst_file.write_text(typst_content, encoding="utf-8")
-
-        # Compile to PDF
-        subprocess.run(
-            ["typst", "compile", str(typst_file), str(output_path)],
-            check=True,
-        )
+        _compile_pdf(video, slides, tmp_path, output_path, compact, slide_mode)
 
 
-def convert_to_pdf_from_content(
-    content: "ExtractedContent",
+# === Phase 2: Generate PDF from extracted JSON ===
+
+
+def render_pdf_from_json(
+    video_url: str,
+    video_title: str,
+    slides: list["SlideData"],
     output_path: Path,
-    detect_duplicates: bool = True,
     compact: bool = False,
     slide_mode: bool = False,
 ) -> None:
-    """Generate a PDF from ExtractedContent (Phase 2 workflow).
+    """Generate PDF from pre-extracted slide data (Phase 2).
 
-    This function works with pre-extracted content from JSON, avoiding
-    the need to re-download or re-process the video.
+    Args:
+        video_url: Video URL for links
+        video_title: Video title for page header
+        slides: Pre-processed slide data from JSON
+        output_path: Output PDF file path
+        compact: Use compact layout
+        slide_mode: One slide per page
     """
-    video = content.get_video()
-    captions = content.get_captions()
-
-    # Build image data lookup: index -> base64 data
-    image_data: dict[int, str] = {
-        img["index"]: img["data_base64"] for img in content.images
-    }
-
-    slides = generate_slides_from_content(captions, image_data, detect_duplicates)
+    video = Video(url=video_url, title=video_title, video_id="")
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         tmp_path = Path(tmp_dir)
 
-        # Write images from base64 data to temp directory
+        # Write images from base64 to temp directory
         for slide in slides:
-            if slide.index in image_data:
-                img_bytes = base64.b64decode(image_data[slide.index])
-                dst_img = tmp_path / f"img{slide.index:04d}.jpg"
-                dst_img.write_bytes(img_bytes)
+            img_bytes = base64.b64decode(slide.image_base64)
+            dst_img = tmp_path / f"img{slide.index:04d}.jpg"
+            dst_img.write_bytes(img_bytes)
 
-        # Generate Typst content
-        typst_content = generate_typst(video, slides, tmp_path, compact, slide_mode)
+        _compile_pdf_from_data(video, slides, tmp_path, output_path, compact, slide_mode)
 
-        # Write Typst file
-        typst_file = tmp_path / "output.typ"
-        typst_file.write_text(typst_content, encoding="utf-8")
 
-        # Compile to PDF
-        subprocess.run(
-            ["typst", "compile", str(typst_file), str(output_path)],
-            check=True,
-        )
+def _compile_pdf(
+    video: Video,
+    slides: list[Slide],
+    image_dir: Path,
+    output_path: Path,
+    compact: bool,
+    slide_mode: bool,
+) -> None:
+    """Compile PDF using Typst from Slide objects."""
+    typst_content = generate_typst(video, slides, image_dir, compact, slide_mode)
+    typst_file = image_dir / "output.typ"
+    typst_file.write_text(typst_content, encoding="utf-8")
+    subprocess.run(
+        ["typst", "compile", str(typst_file), str(output_path)],
+        check=True,
+    )
+
+
+def _compile_pdf_from_data(
+    video: Video,
+    slides: list["SlideData"],
+    image_dir: Path,
+    output_path: Path,
+    compact: bool,
+    slide_mode: bool,
+) -> None:
+    """Compile PDF using Typst from SlideData objects."""
+    typst_content = _generate_typst_from_data(video, slides, image_dir, compact, slide_mode)
+    typst_file = image_dir / "output.typ"
+    typst_file.write_text(typst_content, encoding="utf-8")
+    subprocess.run(
+        ["typst", "compile", str(typst_file), str(output_path)],
+        check=True,
+    )
+
+
+# === Typst generation for Phase 1 (Slide objects) ===
 
 
 def generate_typst(
@@ -106,27 +126,87 @@ def generate_typst(
     compact: bool = False,
     slide_mode: bool = False,
 ) -> str:
-    """Generate complete Typst document content."""
+    """Generate complete Typst document from Slide objects."""
     if slide_mode:
         header = generate_header_slide_mode(video)
         slides_content = generate_slides_typst(
             slides, video.url, image_dir, compact=False, slide_mode=True
         )
-        return f"""{header}
-
-{slides_content}
-"""
+        return f"{header}\n\n{slides_content}\n"
     else:
         header = generate_header(video, compact)
         slides_content = generate_slides_typst(slides, video.url, image_dir, compact)
-
         gutter = "0.3cm" if compact else "0.4cm"
-        return f"""{header}
+        return f"{header}\n\n#columns(2, gutter: {gutter})[\n{slides_content}\n]\n"
 
-#columns(2, gutter: {gutter})[
-{slides_content}
-]
-"""
+
+def generate_slides_typst(
+    slides: list[Slide],
+    url: str,
+    image_dir: Path,
+    compact: bool = False,
+    slide_mode: bool = False,
+) -> str:
+    """Generate Typst content for all slides."""
+    blocks = []
+    for slide in slides:
+        if slide_mode:
+            block = render_slide_page(slide, url, image_dir)
+        elif compact:
+            block = render_slide_compact(slide, url, image_dir)
+        else:
+            block = render_slide_typst(slide, url, image_dir)
+        if block:
+            blocks.append(block)
+    return "\n".join(blocks)
+
+
+# === Typst generation for Phase 2 (SlideData objects) ===
+
+
+def _generate_typst_from_data(
+    video: Video,
+    slides: list["SlideData"],
+    image_dir: Path,
+    compact: bool = False,
+    slide_mode: bool = False,
+) -> str:
+    """Generate complete Typst document from SlideData objects."""
+    if slide_mode:
+        header = generate_header_slide_mode(video)
+        slides_content = _generate_slides_typst_from_data(
+            slides, video.url, image_dir, compact=False, slide_mode=True
+        )
+        return f"{header}\n\n{slides_content}\n"
+    else:
+        header = generate_header(video, compact)
+        slides_content = _generate_slides_typst_from_data(slides, video.url, image_dir, compact)
+        gutter = "0.3cm" if compact else "0.4cm"
+        return f"{header}\n\n#columns(2, gutter: {gutter})[\n{slides_content}\n]\n"
+
+
+def _generate_slides_typst_from_data(
+    slides: list["SlideData"],
+    url: str,
+    image_dir: Path,
+    compact: bool = False,
+    slide_mode: bool = False,
+) -> str:
+    """Generate Typst content for all SlideData slides."""
+    blocks = []
+    for slide in slides:
+        if slide_mode:
+            block = _render_slide_page_from_data(slide, url, image_dir)
+        elif compact:
+            block = _render_slide_compact_from_data(slide, url, image_dir)
+        else:
+            block = _render_slide_typst_from_data(slide, url, image_dir)
+        if block:
+            blocks.append(block)
+    return "\n".join(blocks)
+
+
+# === Shared header generation ===
 
 
 def generate_header(video: Video, compact: bool = False) -> str:
@@ -151,11 +231,10 @@ def generate_header(video: Video, compact: bool = False) -> str:
 
 
 def generate_header_slide_mode(video: Video) -> str:
-    """Generate Typst header for slide mode (one page per slide, presentation size)."""
+    """Generate Typst header for slide mode (16:9 presentation size)."""
     escaped_title = escape_typst(video.title)
     escaped_url = video.url
 
-    # 16:9 aspect ratio page, similar to presentation slides
     return f"""#set page(width: 20cm, height: 11.25cm, margin: 0.6cm)
 #set text(size: 9pt)
 #set par(leading: 0.5em, justify: true)
@@ -166,29 +245,11 @@ def generate_header_slide_mode(video: Video) -> str:
 """
 
 
-def generate_slides_typst(
-    slides: list[Slide],
-    url: str,
-    image_dir: Path,
-    compact: bool = False,
-    slide_mode: bool = False,
-) -> str:
-    """Generate Typst content for all slides."""
-    blocks = []
-    for slide in slides:
-        if slide_mode:
-            block = render_slide_page(slide, url, image_dir)
-        elif compact:
-            block = render_slide_compact(slide, url, image_dir)
-        else:
-            block = render_slide_typst(slide, url, image_dir)
-        if block:
-            blocks.append(block)
-    return "\n".join(blocks)
+# === Slide renderers for Phase 1 (Slide objects) ===
 
 
 def render_slide_typst(slide: Slide, url: str, image_dir: Path) -> str:
-    """Render a single slide as a Typst block."""
+    """Render a single slide as Typst (standard layout)."""
     img_filename = f"img{slide.index:04d}.jpg"
     img_path = image_dir / img_filename
     if not img_path.exists():
@@ -212,7 +273,7 @@ def render_slide_typst(slide: Slide, url: str, image_dir: Path) -> str:
 
 
 def render_slide_compact(slide: Slide, url: str, image_dir: Path) -> str:
-    """Render a slide in compact side-by-side layout (image left, text right)."""
+    """Render a slide in compact side-by-side layout."""
     img_filename = f"img{slide.index:04d}.jpg"
     img_path = image_dir / img_filename
     if not img_path.exists():
@@ -241,6 +302,7 @@ def render_slide_compact(slide: Slide, url: str, image_dir: Path) -> str:
 
 
 def render_slide_page(slide: Slide, url: str, image_dir: Path) -> str:
+    """Render a slide in page mode (one slide per page)."""
     img_filename = f"img{slide.index:04d}.jpg"
     img_path = image_dir / img_filename
     if not img_path.exists():
@@ -253,9 +315,9 @@ def render_slide_page(slide: Slide, url: str, image_dir: Path) -> str:
 
     return f"""
 #block(
-  width: 100%, 
+  width: 100%,
   height: 48%,
-  breakable: false, 
+  breakable: false,
   inset: (y: 2pt),
   spacing: 0pt
 )[
@@ -277,6 +339,83 @@ def render_slide_page(slide: Slide, url: str, image_dir: Path) -> str:
 """
 
 
+# === Slide renderers for Phase 2 (SlideData objects) ===
+
+
+def _render_slide_typst_from_data(slide: "SlideData", url: str, image_dir: Path) -> str:
+    """Render a SlideData as Typst (standard layout)."""
+    img_filename = f"img{slide.index:04d}.jpg"
+    escaped_caption = escape_typst(slide.caption_text)
+    video_link = f"{url}&t={slide.timestamp_seconds}s"
+
+    return f"""#block(breakable: false, width: 100%)[
+  #image("{img_filename}", width: 100%)
+  #v(0.1cm)
+  #text(size: 8pt)[{escaped_caption}]
+  #v(0.05cm)
+  #align(right)[#text(size: 7pt)[#link("{video_link}")[▶ {format_timestamp(slide.timestamp_seconds)}]]]
+  #v(0.2cm)
+]
+"""
+
+
+def _render_slide_compact_from_data(slide: "SlideData", url: str, image_dir: Path) -> str:
+    """Render a SlideData in compact side-by-side layout."""
+    img_filename = f"img{slide.index:04d}.jpg"
+    escaped_caption = escape_typst(slide.caption_text)
+    video_link = f"{url}&t={slide.timestamp_seconds}s"
+
+    return f"""#block(breakable: false, width: 100%)[
+  #grid(
+    columns: (1fr, 1fr),
+    gutter: 0.15cm,
+    image("{img_filename}", width: 100%),
+    [
+      #text(size: 7pt)[{escaped_caption}]
+      #v(0.05cm)
+      #align(right)[#text(size: 6pt)[#link("{video_link}")[▶ {format_timestamp(slide.timestamp_seconds)}]]]
+    ]
+  )
+  #v(0.1cm)
+]
+"""
+
+
+def _render_slide_page_from_data(slide: "SlideData", url: str, image_dir: Path) -> str:
+    """Render a SlideData in page mode (one slide per page)."""
+    img_filename = f"img{slide.index:04d}.jpg"
+    escaped_caption = escape_typst(slide.caption_text)
+    video_link = f"{url}&t={slide.timestamp_seconds}s"
+
+    return f"""
+#block(
+  width: 100%,
+  height: 48%,
+  breakable: false,
+  inset: (y: 2pt),
+  spacing: 0pt
+)[
+  #grid(
+    columns: (0.6fr, 1.4fr),
+    column-gutter: 6pt,
+    align: top,
+    [
+      #set par(leading: 0.4em)
+      #text(size: 8pt)[{escaped_caption}]
+      #v(2pt)
+      #text(size: 7pt)[#link("{video_link}")[▶ {format_timestamp(slide.timestamp_seconds)}]]
+    ],
+    align(right + top)[
+      #image("{img_filename}", width: 100%, height: 100%, fit: "contain")
+    ]
+  )
+]
+"""
+
+
+# === Helpers ===
+
+
 def get_slide_text(captions: list[Caption]) -> str:
     """Combine captions into a single text block."""
     if not captions:
@@ -288,7 +427,6 @@ def get_slide_text(captions: list[Caption]) -> str:
 
 def escape_typst(text: str) -> str:
     """Escape special Typst characters."""
-    # Typst special characters that need escaping
     replacements = [
         ("\\", "\\\\"),
         ("#", "\\#"),

--- a/glancer/render.py
+++ b/glancer/render.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""glancer-render: Render extracted content to HTML or PDF.
+
+This tool takes a JSON file produced by glancer-extract and
+renders it to HTML or PDF format.
+
+Usage:
+    glancer-render INPUT [OUTPUT]
+    glancer-render content.json output.html
+    glancer-render content.json --pdf output.pdf
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from jinja2 import Template
+
+from .schema import ExtractedContent, SlideData
+
+# === HTML rendering ===
+
+HTML_TEMPLATE = """<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ title }}</title>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 0; padding: 20px; background: #f5f5f5; }
+        h1 { text-align: center; margin-bottom: 30px; }
+        h1 a { color: #333; text-decoration: none; }
+        h1 a:hover { text-decoration: underline; }
+        .slides { max-width: 1200px; margin: 0 auto; display: grid; grid-template-columns: repeat(auto-fill, minmax(400px, 1fr)); gap: 20px; }
+        .slide-block { background: white; border-radius: 8px; overflow: hidden; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+        .slide-block.duplicate { opacity: 0.5; }
+        .slide-block img { width: 100%; display: block; }
+        .txt { padding: 15px; font-size: 14px; line-height: 1.5; color: #333; }
+        .to-video { padding: 10px 15px; text-align: right; border-top: 1px solid #eee; }
+        .to-video a { color: #0066cc; text-decoration: none; font-size: 13px; }
+    </style>
+</head>
+<body>
+    <h1><a href="{{ url }}">{{ title }}</a></h1>
+    <div class="slides">
+        {{ slides_html }}
+    </div>
+</body>
+</html>
+"""
+
+
+def render_html(content: ExtractedContent) -> str:
+    """Render ExtractedContent to HTML."""
+    slides_html = "\n".join(_render_slide_html(s, content.video.url) for s in content.slides)
+    return Template(HTML_TEMPLATE).render(
+        title=content.video.title,
+        url=content.video.url,
+        slides_html=slides_html,
+    )
+
+
+def _render_slide_html(slide: SlideData, url: str) -> str:
+    classes = "slide-block duplicate" if slide.is_duplicate else "slide-block"
+    return f"""<div id="slide{slide.index}" class="{classes}">
+    <div class="img"><img src="data:image/jpeg;base64,{slide.image_base64}"/></div>
+    <div class="txt">{slide.caption_text}</div>
+    <div class="to-video"><a href="{url}&t={slide.timestamp_seconds}s">▶ {_format_time(slide.timestamp_seconds)}</a></div>
+</div>"""
+
+
+def _format_time(seconds: int) -> str:
+    h, m, s = seconds // 3600, (seconds % 3600) // 60, seconds % 60
+    return f"{h}:{m:02d}:{s:02d}" if h else f"{m}:{s:02d}"
+
+
+# === PDF rendering ===
+
+
+def render_pdf(content: ExtractedContent, output_path: Path, compact: bool = False, slide_mode: bool = False) -> None:
+    """Render ExtractedContent to PDF using Typst."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp = Path(tmp_dir)
+
+        # Write images
+        for slide in content.slides:
+            (tmp / f"img{slide.index:04d}.jpg").write_bytes(base64.b64decode(slide.image_base64))
+
+        # Generate Typst
+        typst = _generate_typst(content, tmp, compact, slide_mode)
+        typst_file = tmp / "output.typ"
+        typst_file.write_text(typst, encoding="utf-8")
+
+        # Compile
+        subprocess.run(["typst", "compile", str(typst_file), str(output_path)], check=True)
+
+
+def _generate_typst(content: ExtractedContent, img_dir: Path, compact: bool, slide_mode: bool) -> str:
+    title = _escape_typst(content.video.title)
+    url = content.video.url
+
+    if slide_mode:
+        header = f"""#set page(width: 20cm, height: 11.25cm, margin: 0.6cm)
+#set text(size: 9pt)
+#set par(leading: 0.5em, justify: true)
+#align(center)[#text(12pt, weight: "bold")[#link("{url}")[{title}]]]
+"""
+        slides = "\n".join(_render_slide_typst_page(s, url) for s in content.slides)
+        return f"{header}\n{slides}"
+    else:
+        margin = "0.3cm" if compact else "0.5cm"
+        font = "8pt" if compact else "9pt"
+        title_size = "12pt" if compact else "14pt"
+        gutter = "0.3cm" if compact else "0.4cm"
+
+        header = f"""#set page(margin: {margin}, paper: "a4")
+#set text(size: {font})
+#set par(leading: 0.4em, justify: true)
+#align(center)[#text({title_size}, weight: "bold")[#link("{url}")[{title}]]]
+#v(0.3cm)
+"""
+        render_fn = _render_slide_typst_compact if compact else _render_slide_typst
+        slides = "\n".join(render_fn(s, url) for s in content.slides)
+        return f"{header}\n#columns(2, gutter: {gutter})[\n{slides}\n]"
+
+
+def _render_slide_typst(slide: SlideData, url: str) -> str:
+    caption = _escape_typst(slide.caption_text)
+    link = f"{url}&t={slide.timestamp_seconds}s"
+    return f"""#block(breakable: false, width: 100%)[
+  #image("img{slide.index:04d}.jpg", width: 100%)
+  #v(0.1cm)
+  #text(size: 8pt)[{caption}]
+  #v(0.05cm)
+  #align(right)[#text(size: 7pt)[#link("{link}")[▶ {_format_time(slide.timestamp_seconds)}]]]
+  #v(0.2cm)
+]
+"""
+
+
+def _render_slide_typst_compact(slide: SlideData, url: str) -> str:
+    caption = _escape_typst(slide.caption_text)
+    link = f"{url}&t={slide.timestamp_seconds}s"
+    return f"""#block(breakable: false, width: 100%)[
+  #grid(columns: (1fr, 1fr), gutter: 0.15cm,
+    image("img{slide.index:04d}.jpg", width: 100%),
+    [#text(size: 7pt)[{caption}] #v(0.05cm) #align(right)[#text(size: 6pt)[#link("{link}")[▶ {_format_time(slide.timestamp_seconds)}]]]]
+  )
+  #v(0.1cm)
+]
+"""
+
+
+def _render_slide_typst_page(slide: SlideData, url: str) -> str:
+    caption = _escape_typst(slide.caption_text)
+    link = f"{url}&t={slide.timestamp_seconds}s"
+    return f"""
+#block(width: 100%, height: 48%, breakable: false, inset: (y: 2pt), spacing: 0pt)[
+  #grid(columns: (0.6fr, 1.4fr), column-gutter: 6pt, align: top,
+    [#set par(leading: 0.4em) #text(size: 8pt)[{caption}] #v(2pt) #text(size: 7pt)[#link("{link}")[▶ {_format_time(slide.timestamp_seconds)}]]],
+    align(right + top)[#image("img{slide.index:04d}.jpg", width: 100%, height: 100%, fit: "contain")]
+  )
+]
+"""
+
+
+def _escape_typst(text: str) -> str:
+    for old, new in [("\\", "\\\\"), ("#", "\\#"), ("$", "\\$"), ("*", "\\*"), ("_", "\\_"),
+                     ("<", "\\<"), (">", "\\>"), ("@", "\\@"), ("[", "\\["), ("]", "\\]")]:
+        text = text.replace(old, new)
+    return text
+
+
+# === CLI ===
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        prog="glancer-render",
+        description="Render extracted content to HTML or PDF",
+    )
+    parser.add_argument("input", help="Input JSON file from glancer-extract")
+    parser.add_argument("output", nargs="?", help="Output file (default: VIDEO_TITLE.html)")
+    parser.add_argument("--pdf", action="store_true", help="Output PDF instead of HTML")
+    parser.add_argument("--compact", action="store_true", help="Compact PDF layout")
+    parser.add_argument("--slide-mode", action="store_true", help="One slide per page (PDF)")
+    args = parser.parse_args(argv)
+
+    content = ExtractedContent.load(Path(args.input))
+    print(f"Rendering: '{content.video.title}'", file=sys.stderr)
+    print(f"  {len(content.slides)} slides", file=sys.stderr)
+
+    # Determine output path
+    if args.output:
+        output_path = Path(args.output)
+    else:
+        safe_title = re.sub(r'[<>:"/\\|?*]', '_', content.video.title)
+        output_path = Path(f"{safe_title}.pdf" if args.pdf else f"{safe_title}.html")
+
+    # Render
+    if args.pdf:
+        render_pdf(content, output_path, compact=args.compact, slide_mode=args.slide_mode)
+    else:
+        output_path.write_text(render_html(content), encoding="utf-8")
+
+    print(f"Saved: {output_path}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/glancer/schema.py
+++ b/glancer/schema.py
@@ -1,0 +1,106 @@
+"""JSON schema for extracted video content.
+
+This is the ONLY shared code between glancer-extract and glancer-render.
+
+## Schema v1
+
+```json
+{
+  "schema_version": 1,
+  "video": {
+    "url": "https://youtube.com/watch?v=...",
+    "title": "Video Title",
+    "id": "video_id"
+  },
+  "slides": [
+    {
+      "index": 0,
+      "image_base64": "...",
+      "timestamp_seconds": 0,
+      "caption_text": "Combined caption text for this slide",
+      "is_duplicate": false
+    }
+  ],
+  "config": {
+    "seconds_per_shot": 30
+  }
+}
+```
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class VideoMeta:
+    url: str
+    title: str
+    id: str
+
+
+@dataclass(frozen=True)
+class SlideData:
+    index: int
+    image_base64: str
+    timestamp_seconds: int
+    caption_text: str
+    is_duplicate: bool
+
+
+@dataclass
+class ExtractedContent:
+    video: VideoMeta
+    slides: list[SlideData]
+    seconds_per_shot: int = 30
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "video": {"url": self.video.url, "title": self.video.title, "id": self.video.id},
+            "slides": [
+                {
+                    "index": s.index,
+                    "image_base64": s.image_base64,
+                    "timestamp_seconds": s.timestamp_seconds,
+                    "caption_text": s.caption_text,
+                    "is_duplicate": s.is_duplicate,
+                }
+                for s in self.slides
+            ],
+            "config": {"seconds_per_shot": self.seconds_per_shot},
+        }
+
+    def save(self, path: Path) -> None:
+        path.write_text(json.dumps(self.to_dict(), indent=2), encoding="utf-8")
+
+    @classmethod
+    def load(cls, path: Path) -> "ExtractedContent":
+        data = json.loads(path.read_text(encoding="utf-8"))
+        version = data.get("schema_version", 1)
+        if version > SCHEMA_VERSION:
+            raise ValueError(f"Schema version {version} not supported (max: {SCHEMA_VERSION})")
+
+        return cls(
+            video=VideoMeta(
+                url=data["video"]["url"],
+                title=data["video"]["title"],
+                id=data["video"]["id"],
+            ),
+            slides=[
+                SlideData(
+                    index=s["index"],
+                    image_base64=s["image_base64"],
+                    timestamp_seconds=s["timestamp_seconds"],
+                    caption_text=s["caption_text"],
+                    is_duplicate=s["is_duplicate"],
+                )
+                for s in data["slides"]
+            ],
+            seconds_per_shot=data.get("config", {}).get("seconds_per_shot", 30),
+        )

--- a/glancer/slides.py
+++ b/glancer/slides.py
@@ -6,11 +6,15 @@ import math
 import re
 from dataclasses import dataclass, replace
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from .html_builder import embody
-from .image_similarity import find_similar_shots
+from .image_similarity import find_similar_shots, find_similar_shots_from_data
 from .parser import Caption
 from .process import Video
+
+if TYPE_CHECKING:
+    from .content import ExtractedContent
 
 logger = logging.getLogger(__name__)
 
@@ -207,3 +211,100 @@ def overlaps_interval(
     start_a: float, end_a: float, start_b: float, end_b: float
 ) -> bool:
     return start_a <= end_b and end_a >= start_b
+
+
+# === Functions for generating HTML from ExtractedContent ===
+
+
+def convert_to_html_from_content(
+    content: "ExtractedContent",
+    detect_duplicates: bool = True,
+) -> str:
+    """Generate HTML from ExtractedContent (Phase 2 workflow).
+
+    This function works with pre-extracted content from JSON, avoiding
+    the need to re-download or re-process the video.
+    """
+    video = content.get_video()
+    captions = content.get_captions()
+
+    # Build image data lookup: index -> base64 data
+    image_data: dict[int, str] = {
+        img["index"]: img["data_base64"] for img in content.images
+    }
+
+    slides = generate_slides_from_content(captions, image_data, detect_duplicates)
+    slides_html = render_slides_from_content(slides, video.url, image_data)
+    return embody(video, slides_html)
+
+
+def generate_slides_from_content(
+    captions: list[Caption],
+    image_data: dict[int, str],
+    detect_duplicates: bool = True,
+) -> list[Slide]:
+    """Generate slides from captions and pre-extracted image data."""
+    if not captions:
+        return []
+
+    per_slide = captions_per_slide(captions)
+    logger.debug(f"Generated {len(per_slide)} slides from captions")
+
+    if detect_duplicates:
+        # Use the image data directly for similarity detection
+        duplicate_shots = find_similar_shots_from_data(image_data)
+    else:
+        duplicate_shots = set()
+
+    slides: list[Slide] = []
+    for index, slide_captions in enumerate(per_slide):
+        is_duplicate = index in duplicate_shots
+        slides.append(
+            Slide(index=index, captions=slide_captions, duplicate=is_duplicate)
+        )
+
+    if slides:
+        logger.debug(f"Created {len(slides)} slides (indices 0-{len(slides) - 1})")
+
+    return slides
+
+
+def render_slides_from_content(
+    slides: list[Slide], url: str, image_data: dict[int, str]
+) -> str:
+    """Render all slides to HTML using pre-extracted image data."""
+    blocks = [render_slide_from_content(slide, url, image_data) for slide in slides]
+    return "\n".join(blocks)
+
+
+def render_slide_from_content(
+    slide: Slide, url: str, image_data: dict[int, str]
+) -> str:
+    """Render a single slide using pre-extracted image data."""
+    image_block = slide_block_from_content(url, slide.index, slide.duplicate, image_data)
+    if not image_block:
+        return ""
+    text_block = caps(slide.captions)
+    to_video = to_video_block(url, slide.index)
+    return f"{image_block}{text_block}{to_video}</div>"
+
+
+def slide_block_from_content(
+    url: str, shot: int, duplicate: bool, image_data: dict[int, str]
+) -> str:
+    """Generate HTML for a slide image using pre-extracted base64 data."""
+    if shot not in image_data:
+        logger.warning(f"Missing image data for slide {shot}")
+        return ""
+
+    encoded = image_data[shot]
+    classes = ["slide-block"]
+    if duplicate:
+        classes.append("duplicate")
+    class_attr = " ".join(classes)
+    return (
+        f"<div id='slide{shot}' class='{class_attr}'>\n"
+        "\t<div class='img'>\n"
+        f"\t\t<img src='data:image/jpeg;base64, {encoded}'/></a>\n"
+        "\t</div>\n"
+    )

--- a/glancer/slides.py
+++ b/glancer/slides.py
@@ -9,12 +9,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from .html_builder import embody
-from .image_similarity import find_similar_shots, find_similar_shots_from_data
+from .image_similarity import find_similar_shots
 from .parser import Caption
 from .process import Video
 
 if TYPE_CHECKING:
-    from .content import ExtractedContent
+    from .content import SlideData
 
 logger = logging.getLogger(__name__)
 
@@ -28,21 +28,16 @@ class Slide:
     duplicate: bool
 
 
+# === Phase 1: Generate HTML from video processing ===
+
+
 def convert_to_html(
     video: Video,
     directory: Path,
     captions: list[Caption],
     detect_duplicates: bool = True,
 ) -> str:
-    return captions_to_html(video, directory, captions, detect_duplicates)
-
-
-def captions_to_html(
-    video: Video,
-    directory: Path,
-    captions: list[Caption],
-    detect_duplicates: bool = True,
-) -> str:
+    """Generate HTML from video processing results (Phase 1 or standalone)."""
     slides = generate_slides(captions, directory, detect_duplicates)
     slides_html = render_slides(slides, video.url, directory)
     return embody(video, slides_html)
@@ -51,6 +46,7 @@ def captions_to_html(
 def generate_slides(
     captions: list[Caption], directory: Path, detect_duplicates: bool = True
 ) -> list[Slide]:
+    """Generate Slide objects from captions and image directory."""
     if not captions:
         return []
 
@@ -76,11 +72,13 @@ def generate_slides(
 
 
 def render_slides(slides: list[Slide], url: str, directory: Path) -> str:
+    """Render all slides to HTML."""
     blocks = [render_slide(slide, url, directory) for slide in slides]
     return "\n".join(blocks)
 
 
 def render_slide(slide: Slide, url: str, directory: Path) -> str:
+    """Render a single slide to HTML."""
     image_block = slide_block(url, directory, slide.index, slide.duplicate)
     if not image_block:
         return ""
@@ -90,9 +88,9 @@ def render_slide(slide: Slide, url: str, directory: Path) -> str:
 
 
 def slide_block(url: str, directory: Path, shot: int, duplicate: bool) -> str:
+    """Generate HTML for a slide image from file."""
     img_path = directory / f"glancer-img{shot:04d}.jpg"
     if not img_path.exists():
-        # Log available images around this slide number
         all_images = sorted(directory.glob("glancer-img*.jpg"))
         image_numbers = []
         for img in all_images:
@@ -102,10 +100,7 @@ def slide_block(url: str, directory: Path, shot: int, duplicate: bool) -> str:
             except ValueError:
                 pass
 
-        context = []
-        for num in image_numbers:
-            if abs(num - shot) <= 5:
-                context.append(num)
+        context = [num for num in image_numbers if abs(num - shot) <= 5]
 
         logger.warning(
             f"Missing image for slide {shot}: {img_path}\n"
@@ -116,6 +111,49 @@ def slide_block(url: str, directory: Path, shot: int, duplicate: bool) -> str:
         return ""
     data = img_path.read_bytes()
     encoded = base64.b64encode(data).decode("ascii")
+    return _slide_block_html(shot, encoded, duplicate)
+
+
+# === Phase 2: Generate HTML from extracted JSON ===
+
+
+def render_html_from_json(video_url: str, video_title: str, slides: list["SlideData"]) -> str:
+    """Generate HTML from pre-extracted slide data (Phase 2).
+
+    Args:
+        video_url: Video URL for links
+        video_title: Video title for page header
+        slides: Pre-processed slide data from JSON
+
+    Returns:
+        Complete HTML document
+    """
+    from .process import Video
+    video = Video(url=video_url, title=video_title, video_id="")
+    slides_html = _render_slides_from_data(slides, video_url)
+    return embody(video, slides_html)
+
+
+def _render_slides_from_data(slides: list["SlideData"], url: str) -> str:
+    """Render pre-extracted slides to HTML."""
+    blocks = []
+    for slide in slides:
+        block = _render_slide_from_data(slide, url)
+        if block:
+            blocks.append(block)
+    return "\n".join(blocks)
+
+
+def _render_slide_from_data(slide: "SlideData", url: str) -> str:
+    """Render a single pre-extracted slide to HTML."""
+    image_block = _slide_block_html(slide.index, slide.image_base64, slide.is_duplicate)
+    text_block = f"\t<div class='txt'>\n\t\t{slide.caption_text}\n\t</div>" if slide.caption_text else "\t<div class='txt'>\n\t</div>"
+    to_video = to_video_block(url, slide.index)
+    return f"{image_block}{text_block}{to_video}</div>"
+
+
+def _slide_block_html(shot: int, image_base64: str, duplicate: bool) -> str:
+    """Generate HTML for a slide image from base64 data."""
     classes = ["slide-block"]
     if duplicate:
         classes.append("duplicate")
@@ -123,12 +161,16 @@ def slide_block(url: str, directory: Path, shot: int, duplicate: bool) -> str:
     return (
         f"<div id='slide{shot}' class='{class_attr}'>\n"
         "\t<div class='img'>\n"
-        f"\t\t<img src='data:image/jpeg;base64, {encoded}'/></a>\n"
+        f"\t\t<img src='data:image/jpeg;base64, {image_base64}'/></a>\n"
         "\t</div>\n"
     )
 
 
+# === Caption processing (shared) ===
+
+
 def to_video_block(url: str, shot: int) -> str:
+    """Generate the "go to video" link block."""
     when = shot_seconds(shot, SECONDS_PER_SHOT)
     return (
         f"<div class='to-video'><a title='Go to video at timestamp {when}s' "
@@ -137,6 +179,7 @@ def to_video_block(url: str, shot: int) -> str:
 
 
 def caps(captions: list[Caption]) -> str:
+    """Generate caption text HTML from Caption objects."""
     if not captions:
         return "\t<div class='txt'>\n\t</div>"
 
@@ -149,11 +192,30 @@ def caps(captions: list[Caption]) -> str:
     return f"\t<div class='txt'>\n\t\t{combined}\n\t</div>"
 
 
+def get_caption_texts(captions: list[Caption]) -> list[str]:
+    """Get combined caption text for each slide (for JSON extraction).
+
+    Returns:
+        List of caption texts, one per slide index
+    """
+    per_slide = captions_per_slide(captions)
+    texts = []
+    for slide_captions in per_slide:
+        paragraphs = [normalize_caption_text(c.text) for c in slide_captions]
+        paragraphs = [t for t in paragraphs if t]
+        combined = " ".join(paragraphs)
+        combined = " ".join(combined.split())
+        texts.append(combined)
+    return texts
+
+
 def normalize_caption_text(text: str) -> str:
+    """Normalize caption text (remove extra whitespace)."""
     return " ".join(text.strip().replace("\n", " ").split())
 
 
 def captions_per_slide(captions: list[Caption]) -> list[list[Caption]]:
+    """Group captions by slide (30-second intervals)."""
     cleaned = [clean_caption(caption) for caption in captions]
     cleaned = [caption for caption in cleaned if caption.text]
     total_shots = num_shots(cleaned, SECONDS_PER_SHOT)
@@ -163,8 +225,6 @@ def captions_per_slide(captions: list[Caption]) -> list[list[Caption]]:
     slides: list[list[Caption]] = []
     for shot_index in range(total_shots):
         shot_start = shot_index * SECONDS_PER_SHOT
-        # For the last slide, extend to capture all remaining captions
-        # instead of cutting off at the next 30-second boundary
         if shot_index == total_shots - 1:
             shot_end = cleaned[-1].end
         else:
@@ -179,21 +239,22 @@ def captions_per_slide(captions: list[Caption]) -> list[list[Caption]]:
 
 
 def shot_seconds(shot_number: int, secs_per_shot: int) -> int:
+    """Convert shot number to seconds."""
     return shot_number * secs_per_shot
 
 
 def num_shots(captions: list[Caption], secs_per_shot: int) -> int:
+    """Calculate number of shots needed for captions."""
     if not captions:
         return 0
 
     last_end = captions[-1].end
-    # Use floor to match ffmpeg's behavior with fps=1/30
-    # ffmpeg generates frames at 0s, 30s, 60s, ... and stops when time exceeds duration
     shots = int(math.floor(last_end / secs_per_shot))
     return max(1, shots)
 
 
 def clean_caption(caption: Caption) -> Caption:
+    """Clean HTML tags and normalize whitespace in caption."""
     unescaped = html.unescape(caption.text)
     cleaned_text = strip_tags(unescaped)
     normalized = cleaned_text.replace("\u00a0", " ")
@@ -204,107 +265,12 @@ TAG_RE = re.compile(r"<[^>]+>")
 
 
 def strip_tags(text: str) -> str:
+    """Remove HTML tags from text."""
     return TAG_RE.sub("", text)
 
 
 def overlaps_interval(
     start_a: float, end_a: float, start_b: float, end_b: float
 ) -> bool:
+    """Check if two time intervals overlap."""
     return start_a <= end_b and end_a >= start_b
-
-
-# === Functions for generating HTML from ExtractedContent ===
-
-
-def convert_to_html_from_content(
-    content: "ExtractedContent",
-    detect_duplicates: bool = True,
-) -> str:
-    """Generate HTML from ExtractedContent (Phase 2 workflow).
-
-    This function works with pre-extracted content from JSON, avoiding
-    the need to re-download or re-process the video.
-    """
-    video = content.get_video()
-    captions = content.get_captions()
-
-    # Build image data lookup: index -> base64 data
-    image_data: dict[int, str] = {
-        img["index"]: img["data_base64"] for img in content.images
-    }
-
-    slides = generate_slides_from_content(captions, image_data, detect_duplicates)
-    slides_html = render_slides_from_content(slides, video.url, image_data)
-    return embody(video, slides_html)
-
-
-def generate_slides_from_content(
-    captions: list[Caption],
-    image_data: dict[int, str],
-    detect_duplicates: bool = True,
-) -> list[Slide]:
-    """Generate slides from captions and pre-extracted image data."""
-    if not captions:
-        return []
-
-    per_slide = captions_per_slide(captions)
-    logger.debug(f"Generated {len(per_slide)} slides from captions")
-
-    if detect_duplicates:
-        # Use the image data directly for similarity detection
-        duplicate_shots = find_similar_shots_from_data(image_data)
-    else:
-        duplicate_shots = set()
-
-    slides: list[Slide] = []
-    for index, slide_captions in enumerate(per_slide):
-        is_duplicate = index in duplicate_shots
-        slides.append(
-            Slide(index=index, captions=slide_captions, duplicate=is_duplicate)
-        )
-
-    if slides:
-        logger.debug(f"Created {len(slides)} slides (indices 0-{len(slides) - 1})")
-
-    return slides
-
-
-def render_slides_from_content(
-    slides: list[Slide], url: str, image_data: dict[int, str]
-) -> str:
-    """Render all slides to HTML using pre-extracted image data."""
-    blocks = [render_slide_from_content(slide, url, image_data) for slide in slides]
-    return "\n".join(blocks)
-
-
-def render_slide_from_content(
-    slide: Slide, url: str, image_data: dict[int, str]
-) -> str:
-    """Render a single slide using pre-extracted image data."""
-    image_block = slide_block_from_content(url, slide.index, slide.duplicate, image_data)
-    if not image_block:
-        return ""
-    text_block = caps(slide.captions)
-    to_video = to_video_block(url, slide.index)
-    return f"{image_block}{text_block}{to_video}</div>"
-
-
-def slide_block_from_content(
-    url: str, shot: int, duplicate: bool, image_data: dict[int, str]
-) -> str:
-    """Generate HTML for a slide image using pre-extracted base64 data."""
-    if shot not in image_data:
-        logger.warning(f"Missing image data for slide {shot}")
-        return ""
-
-    encoded = image_data[shot]
-    classes = ["slide-block"]
-    if duplicate:
-        classes.append("duplicate")
-    class_attr = " ".join(classes)
-    return (
-        f"<div id='slide{shot}' class='{class_attr}'>\n"
-        "\t<div class='img'>\n"
-        f"\t\t<img src='data:image/jpeg;base64, {encoded}'/></a>\n"
-        "\t</div>\n"
-    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ dev = [
 
 [project.scripts]
 glancer = "glancer.cli:main"
+glancer-extract = "glancer.extract:main"
+glancer-render = "glancer.render:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/test_captions.py
+++ b/tests/test_captions.py
@@ -6,7 +6,7 @@ from glancer.slides import (
     Slide,
     generate_slides,
     render_slides,
-    captions_to_html,
+    convert_to_html,
     normalize_caption_text,
 )
 from glancer.parser import Caption
@@ -47,13 +47,13 @@ def test_render_slides(sample_captions: list[Caption], tmp_path: Path) -> None:
     assert "data:image/jpeg;base64" in rendered_html
 
 
-def test_captions_to_html(
+def test_convert_to_html(
     sample_captions: list[Caption], sample_video: Video, tmp_path: Path
 ) -> None:
     for i in range(2):
         create_test_image(tmp_path / f"glancer-img{i:04d}.jpg")
 
-    html = captions_to_html(sample_video, tmp_path, sample_captions)
+    html = convert_to_html(sample_video, tmp_path, sample_captions)
     assert isinstance(html, str)
     assert "Sample Video" in html
     assert "slide-block" in html

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,19 @@
 from __future__ import annotations
 
+import json
 from unittest.mock import MagicMock, patch
 from pathlib import Path
 import pytest
+from PIL import Image
 from glancer.cli import main
+from glancer.content import ExtractedContent
 from glancer.process import Video
+
+
+def _create_test_image(path: Path, color: tuple[int, int, int]) -> None:
+    """Create a simple test JPEG image."""
+    image = Image.new("RGB", (64, 64), color=color)
+    image.save(path, format="JPEG")
 
 
 @pytest.fixture
@@ -14,6 +23,9 @@ def mock_process_video(tmp_path: Path):
         video_dir.mkdir(parents=True, exist_ok=True)
         captions_path = video_dir / "video_id.en.srt"
         captions_path.touch()
+        # Create test images
+        _create_test_image(video_dir / "glancer-img0000.jpg", (200, 100, 100))
+        _create_test_image(video_dir / "glancer-img0001.jpg", (100, 200, 100))
         mock.return_value = (
             video_dir,
             Video(url="http://example.com", title="Test Video", video_id="video_id"),
@@ -55,6 +67,7 @@ def test_main(
     assert output_path.exists()
     assert output_path.read_text() == "<html></html>"
 
+
 def test_main_playlist(tmp_path: Path) -> None:
     with patch("glancer.cli.run") as mock_run:
         main(["--auto-cleanup", "http://playlist.test", str(tmp_path)])
@@ -67,4 +80,106 @@ def test_main_playlist(tmp_path: Path) -> None:
         output_pdf=False,
         compact=False,
         slide_mode=False,
+        extract_json=False,
+        from_json=None,
     )
+
+
+def test_main_extract_json(
+    mock_process_video: MagicMock,
+    mock_parse_srt: MagicMock,
+    tmp_path: Path,
+):
+    """Test --extract-json outputs JSON instead of HTML."""
+    output_path = tmp_path / "output.json"
+    main(
+        [
+            "--extract-json",
+            "http://example.com/video",
+            str(output_path),
+        ]
+    )
+    mock_process_video.assert_called_once()
+    mock_parse_srt.assert_called_once()
+    assert output_path.exists()
+    # Verify valid JSON
+    data = json.loads(output_path.read_text())
+    assert "video_url" in data
+    assert "images" in data
+    assert "captions" in data
+
+
+def test_main_from_json(tmp_path: Path):
+    """Test --from-json generates HTML from existing JSON."""
+    # Create a sample JSON file
+    json_path = tmp_path / "content.json"
+    content = ExtractedContent(
+        schema_version=1,
+        video_url="http://example.com",
+        video_title="Test Video",
+        video_id="test123",
+        captions=[{"start": 0.0, "end": 10.0, "text": "Test caption"}],
+        images=[],
+        seconds_per_shot=30,
+    )
+    content.save(json_path)
+
+    output_path = tmp_path / "output.html"
+    with patch("glancer.cli.convert_to_html_from_content") as mock_convert:
+        mock_convert.return_value = "<html>from json</html>"
+        main(["--from-json", str(json_path), str(output_path)])
+    mock_convert.assert_called_once()
+    assert output_path.exists()
+
+
+def test_main_from_json_pdf(tmp_path: Path):
+    """Test --from-json with --pdf generates PDF from JSON."""
+    # Create a sample JSON file
+    json_path = tmp_path / "content.json"
+    content = ExtractedContent(
+        schema_version=1,
+        video_url="http://example.com",
+        video_title="Test Video",
+        video_id="test123",
+        captions=[],
+        images=[],
+        seconds_per_shot=30,
+    )
+    content.save(json_path)
+
+    output_path = tmp_path / "output.pdf"
+    with patch("glancer.cli.convert_to_pdf_from_content") as mock_convert:
+        main(["--from-json", str(json_path), "--pdf", str(output_path)])
+    mock_convert.assert_called_once()
+
+
+def test_main_rejects_both_positional_args_with_from_json(tmp_path: Path):
+    """Test that both positional args (url and destination) with --from-json is rejected."""
+    json_path = tmp_path / "content.json"
+    json_path.write_text('{"schema_version": 1}')
+
+    # When using --from-json with two positional args, the second is interpreted as destination
+    # and an error is raised
+    with pytest.raises(SystemExit):
+        main(["--from-json", str(json_path), "output.html", "extra_arg"])
+
+
+def test_main_rejects_extract_json_with_pdf():
+    """Test that --extract-json and --pdf cannot be used together."""
+    with pytest.raises(SystemExit):
+        main(["--extract-json", "--pdf", "http://example.com"])
+
+
+def test_main_rejects_extract_json_with_from_json(tmp_path: Path):
+    """Test that --extract-json and --from-json cannot be used together."""
+    json_path = tmp_path / "content.json"
+    json_path.write_text('{"schema_version": 1}')
+
+    with pytest.raises(SystemExit):
+        main(["--extract-json", "--from-json", str(json_path)])
+
+
+def test_main_requires_url_or_from_json():
+    """Test that either URL or --from-json is required."""
+    with pytest.raises(SystemExit):
+        main([])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 from PIL import Image
 from glancer.cli import main
-from glancer.content import ExtractedContent
+from glancer.content import ExtractedContent, VideoInfo, SlideData
 from glancer.process import Video
 
 
@@ -102,64 +102,52 @@ def test_main_extract_json(
     mock_process_video.assert_called_once()
     mock_parse_srt.assert_called_once()
     assert output_path.exists()
-    # Verify valid JSON
+    # Verify valid JSON with new schema
     data = json.loads(output_path.read_text())
-    assert "video_url" in data
-    assert "images" in data
-    assert "captions" in data
+    assert "video" in data
+    assert "slides" in data
+    assert data["video"]["url"] == "http://example.com"
 
 
 def test_main_from_json(tmp_path: Path):
     """Test --from-json generates HTML from existing JSON."""
-    # Create a sample JSON file
     json_path = tmp_path / "content.json"
     content = ExtractedContent(
-        schema_version=1,
-        video_url="http://example.com",
-        video_title="Test Video",
-        video_id="test123",
-        captions=[{"start": 0.0, "end": 10.0, "text": "Test caption"}],
-        images=[],
+        video=VideoInfo(url="http://example.com", title="Test Video", id="test123"),
+        slides=[],
         seconds_per_shot=30,
     )
     content.save(json_path)
 
     output_path = tmp_path / "output.html"
-    with patch("glancer.cli.convert_to_html_from_content") as mock_convert:
-        mock_convert.return_value = "<html>from json</html>"
+    with patch("glancer.cli.render_html_from_json") as mock_render:
+        mock_render.return_value = "<html>from json</html>"
         main(["--from-json", str(json_path), str(output_path)])
-    mock_convert.assert_called_once()
+    mock_render.assert_called_once()
     assert output_path.exists()
 
 
 def test_main_from_json_pdf(tmp_path: Path):
     """Test --from-json with --pdf generates PDF from JSON."""
-    # Create a sample JSON file
     json_path = tmp_path / "content.json"
     content = ExtractedContent(
-        schema_version=1,
-        video_url="http://example.com",
-        video_title="Test Video",
-        video_id="test123",
-        captions=[],
-        images=[],
+        video=VideoInfo(url="http://example.com", title="Test Video", id="test123"),
+        slides=[],
         seconds_per_shot=30,
     )
     content.save(json_path)
 
     output_path = tmp_path / "output.pdf"
-    with patch("glancer.cli.convert_to_pdf_from_content") as mock_convert:
+    with patch("glancer.cli.render_pdf_from_json") as mock_render:
         main(["--from-json", str(json_path), "--pdf", str(output_path)])
-    mock_convert.assert_called_once()
+    mock_render.assert_called_once()
 
 
 def test_main_rejects_both_positional_args_with_from_json(tmp_path: Path):
-    """Test that both positional args (url and destination) with --from-json is rejected."""
+    """Test that both positional args with --from-json is rejected."""
     json_path = tmp_path / "content.json"
     json_path.write_text('{"schema_version": 1}')
 
-    # When using --from-json with two positional args, the second is interpreted as destination
-    # and an error is raised
     with pytest.raises(SystemExit):
         main(["--from-json", str(json_path), "output.html", "extra_arg"])
 

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -1,0 +1,243 @@
+"""Tests for content extraction and JSON serialization."""
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+
+import pytest
+from PIL import Image, ImageDraw
+
+from glancer.content import CONTENT_SCHEMA_VERSION, ExtractedContent
+from glancer.parser import Caption
+from glancer.process import Video
+
+
+def _create_test_image(path: Path, color: tuple[int, int, int]) -> None:
+    """Create a simple test JPEG image."""
+    image = Image.new("RGB", (64, 64), color=color)
+    draw = ImageDraw.Draw(image)
+    draw.rectangle((10, 10, 54, 54), fill=(color[0] // 2, color[1] // 2, color[2] // 2))
+    image.save(path, format="JPEG")
+
+
+def _create_test_images(directory: Path, count: int = 3) -> None:
+    """Create multiple test images in the expected naming format."""
+    colors = [(200, 100, 100), (100, 200, 100), (100, 100, 200)]
+    for i in range(count):
+        path = directory / f"glancer-img{i:04d}.jpg"
+        _create_test_image(path, colors[i % len(colors)])
+
+
+@pytest.fixture
+def sample_video() -> Video:
+    return Video(
+        url="https://www.youtube.com/watch?v=test123",
+        title="Test Video Title",
+        video_id="test123",
+    )
+
+
+@pytest.fixture
+def sample_captions() -> list[Caption]:
+    return [
+        Caption(start=0.0, end=10.0, text="First caption"),
+        Caption(start=10.0, end=25.0, text="Second caption"),
+        Caption(start=30.0, end=45.0, text="Third caption"),
+    ]
+
+
+class TestExtractedContentFromProcessing:
+    def test_creates_content_from_video_and_captions(
+        self, tmp_path: Path, sample_video: Video, sample_captions: list[Caption]
+    ) -> None:
+        _create_test_images(tmp_path)
+
+        content = ExtractedContent.from_processing(
+            sample_video, sample_captions, tmp_path
+        )
+
+        assert content.schema_version == CONTENT_SCHEMA_VERSION
+        assert content.video_url == sample_video.url
+        assert content.video_title == sample_video.title
+        assert content.video_id == sample_video.video_id
+        assert len(content.captions) == 3
+        assert len(content.images) == 3
+
+    def test_encodes_images_as_base64(
+        self, tmp_path: Path, sample_video: Video, sample_captions: list[Caption]
+    ) -> None:
+        _create_test_images(tmp_path, count=1)
+
+        content = ExtractedContent.from_processing(
+            sample_video, sample_captions, tmp_path
+        )
+
+        assert len(content.images) == 1
+        img_data = content.images[0]
+        assert img_data["index"] == 0
+        assert img_data["timestamp_seconds"] == 0
+        # Verify base64 is valid by decoding
+        decoded = base64.b64decode(img_data["data_base64"])
+        assert len(decoded) > 0
+
+    def test_handles_empty_captions(
+        self, tmp_path: Path, sample_video: Video
+    ) -> None:
+        _create_test_images(tmp_path)
+
+        content = ExtractedContent.from_processing(sample_video, [], tmp_path)
+
+        assert content.captions == []
+        assert len(content.images) == 3
+
+    def test_handles_missing_images(
+        self, tmp_path: Path, sample_video: Video, sample_captions: list[Caption]
+    ) -> None:
+        # No images created
+
+        content = ExtractedContent.from_processing(
+            sample_video, sample_captions, tmp_path
+        )
+
+        assert content.images == []
+        assert len(content.captions) == 3
+
+
+class TestExtractedContentSerialization:
+    def test_to_json_produces_valid_json(
+        self, tmp_path: Path, sample_video: Video, sample_captions: list[Caption]
+    ) -> None:
+        _create_test_images(tmp_path)
+        content = ExtractedContent.from_processing(
+            sample_video, sample_captions, tmp_path
+        )
+
+        json_str = content.to_json()
+        parsed = json.loads(json_str)
+
+        assert parsed["schema_version"] == CONTENT_SCHEMA_VERSION
+        assert parsed["video_url"] == sample_video.url
+        assert parsed["video_title"] == sample_video.title
+        assert len(parsed["captions"]) == 3
+        assert len(parsed["images"]) == 3
+
+    def test_save_and_load_roundtrip(
+        self, tmp_path: Path, sample_video: Video, sample_captions: list[Caption]
+    ) -> None:
+        # Create images in a subdirectory
+        img_dir = tmp_path / "images"
+        img_dir.mkdir()
+        _create_test_images(img_dir)
+
+        content = ExtractedContent.from_processing(
+            sample_video, sample_captions, img_dir
+        )
+
+        # Save to file
+        json_path = tmp_path / "content.json"
+        content.save(json_path)
+        assert json_path.exists()
+
+        # Load from file
+        loaded = ExtractedContent.load(json_path)
+
+        assert loaded.schema_version == content.schema_version
+        assert loaded.video_url == content.video_url
+        assert loaded.video_title == content.video_title
+        assert loaded.video_id == content.video_id
+        assert loaded.captions == content.captions
+        assert len(loaded.images) == len(content.images)
+        for orig, loaded_img in zip(content.images, loaded.images):
+            assert orig["index"] == loaded_img["index"]
+            assert orig["data_base64"] == loaded_img["data_base64"]
+
+    def test_load_rejects_unsupported_schema_version(self, tmp_path: Path) -> None:
+        json_path = tmp_path / "future_content.json"
+        json_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": CONTENT_SCHEMA_VERSION + 1,
+                    "video_url": "http://test",
+                    "video_title": "Test",
+                    "video_id": "test",
+                    "captions": [],
+                    "images": [],
+                    "seconds_per_shot": 30,
+                }
+            )
+        )
+
+        with pytest.raises(ValueError, match="Unsupported schema version"):
+            ExtractedContent.load(json_path)
+
+
+class TestExtractedContentHelpers:
+    def test_get_video_reconstructs_video_object(
+        self, tmp_path: Path, sample_video: Video, sample_captions: list[Caption]
+    ) -> None:
+        _create_test_images(tmp_path)
+        content = ExtractedContent.from_processing(
+            sample_video, sample_captions, tmp_path
+        )
+
+        video = content.get_video()
+
+        assert video.url == sample_video.url
+        assert video.title == sample_video.title
+        assert video.video_id == sample_video.video_id
+
+    def test_get_captions_reconstructs_caption_objects(
+        self, tmp_path: Path, sample_video: Video, sample_captions: list[Caption]
+    ) -> None:
+        _create_test_images(tmp_path)
+        content = ExtractedContent.from_processing(
+            sample_video, sample_captions, tmp_path
+        )
+
+        captions = content.get_captions()
+
+        assert len(captions) == len(sample_captions)
+        for orig, loaded in zip(sample_captions, captions):
+            assert orig.start == loaded.start
+            assert orig.end == loaded.end
+            assert orig.text == loaded.text
+
+    def test_get_image_data_returns_decoded_bytes(
+        self, tmp_path: Path, sample_video: Video, sample_captions: list[Caption]
+    ) -> None:
+        _create_test_images(tmp_path, count=1)
+        content = ExtractedContent.from_processing(
+            sample_video, sample_captions, tmp_path
+        )
+
+        data = content.get_image_data(0)
+
+        assert data is not None
+        assert len(data) > 0
+        # Verify it's valid JPEG by checking magic bytes
+        assert data[:2] == b"\xff\xd8"
+
+    def test_get_image_data_returns_none_for_missing(
+        self, tmp_path: Path, sample_video: Video, sample_captions: list[Caption]
+    ) -> None:
+        _create_test_images(tmp_path, count=1)
+        content = ExtractedContent.from_processing(
+            sample_video, sample_captions, tmp_path
+        )
+
+        data = content.get_image_data(999)
+
+        assert data is None
+
+    def test_get_image_indices_returns_sorted_list(
+        self, tmp_path: Path, sample_video: Video, sample_captions: list[Caption]
+    ) -> None:
+        _create_test_images(tmp_path, count=3)
+        content = ExtractedContent.from_processing(
+            sample_video, sample_captions, tmp_path
+        )
+
+        indices = content.get_image_indices()
+
+        assert indices == [0, 1, 2]

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -6,238 +6,185 @@ import json
 from pathlib import Path
 
 import pytest
-from PIL import Image, ImageDraw
+from PIL import Image
 
-from glancer.content import CONTENT_SCHEMA_VERSION, ExtractedContent
-from glancer.parser import Caption
-from glancer.process import Video
+from glancer.content import (
+    SCHEMA_VERSION,
+    ExtractedContent,
+    SlideData,
+    VideoInfo,
+    extract_content,
+)
 
 
 def _create_test_image(path: Path, color: tuple[int, int, int]) -> None:
     """Create a simple test JPEG image."""
     image = Image.new("RGB", (64, 64), color=color)
-    draw = ImageDraw.Draw(image)
-    draw.rectangle((10, 10, 54, 54), fill=(color[0] // 2, color[1] // 2, color[2] // 2))
     image.save(path, format="JPEG")
 
 
 def _create_test_images(directory: Path, count: int = 3) -> None:
-    """Create multiple test images in the expected naming format."""
+    """Create test images in the expected naming format."""
     colors = [(200, 100, 100), (100, 200, 100), (100, 100, 200)]
     for i in range(count):
         path = directory / f"glancer-img{i:04d}.jpg"
         _create_test_image(path, colors[i % len(colors)])
 
 
-@pytest.fixture
-def sample_video() -> Video:
-    return Video(
-        url="https://www.youtube.com/watch?v=test123",
-        title="Test Video Title",
-        video_id="test123",
-    )
+class TestExtractContent:
+    def test_creates_content_from_processing(self, tmp_path: Path) -> None:
+        _create_test_images(tmp_path, count=2)
+        caption_texts = ["First slide caption", "Second slide caption"]
+        duplicates = {1}  # Mark second as duplicate
 
-
-@pytest.fixture
-def sample_captions() -> list[Caption]:
-    return [
-        Caption(start=0.0, end=10.0, text="First caption"),
-        Caption(start=10.0, end=25.0, text="Second caption"),
-        Caption(start=30.0, end=45.0, text="Third caption"),
-    ]
-
-
-class TestExtractedContentFromProcessing:
-    def test_creates_content_from_video_and_captions(
-        self, tmp_path: Path, sample_video: Video, sample_captions: list[Caption]
-    ) -> None:
-        _create_test_images(tmp_path)
-
-        content = ExtractedContent.from_processing(
-            sample_video, sample_captions, tmp_path
+        content = extract_content(
+            video_url="http://example.com",
+            video_title="Test Video",
+            video_id="test123",
+            image_dir=tmp_path,
+            caption_texts=caption_texts,
+            duplicate_indices=duplicates,
         )
 
-        assert content.schema_version == CONTENT_SCHEMA_VERSION
-        assert content.video_url == sample_video.url
-        assert content.video_title == sample_video.title
-        assert content.video_id == sample_video.video_id
-        assert len(content.captions) == 3
-        assert len(content.images) == 3
+        assert content.video.url == "http://example.com"
+        assert content.video.title == "Test Video"
+        assert content.video.id == "test123"
+        assert len(content.slides) == 2
+        assert content.slides[0].caption_text == "First slide caption"
+        assert content.slides[0].is_duplicate is False
+        assert content.slides[1].is_duplicate is True
 
-    def test_encodes_images_as_base64(
-        self, tmp_path: Path, sample_video: Video, sample_captions: list[Caption]
-    ) -> None:
+    def test_encodes_images_as_base64(self, tmp_path: Path) -> None:
         _create_test_images(tmp_path, count=1)
 
-        content = ExtractedContent.from_processing(
-            sample_video, sample_captions, tmp_path
+        content = extract_content(
+            video_url="http://example.com",
+            video_title="Test",
+            video_id="test",
+            image_dir=tmp_path,
+            caption_texts=[""],
+            duplicate_indices=set(),
         )
 
-        assert len(content.images) == 1
-        img_data = content.images[0]
-        assert img_data["index"] == 0
-        assert img_data["timestamp_seconds"] == 0
-        # Verify base64 is valid by decoding
-        decoded = base64.b64decode(img_data["data_base64"])
+        assert len(content.slides) == 1
+        # Verify base64 is valid
+        decoded = base64.b64decode(content.slides[0].image_base64)
         assert len(decoded) > 0
+        # JPEG magic bytes
+        assert decoded[:2] == b"\xff\xd8"
 
-    def test_handles_empty_captions(
-        self, tmp_path: Path, sample_video: Video
-    ) -> None:
-        _create_test_images(tmp_path)
-
-        content = ExtractedContent.from_processing(sample_video, [], tmp_path)
-
-        assert content.captions == []
-        assert len(content.images) == 3
-
-    def test_handles_missing_images(
-        self, tmp_path: Path, sample_video: Video, sample_captions: list[Caption]
-    ) -> None:
+    def test_handles_missing_images(self, tmp_path: Path) -> None:
         # No images created
-
-        content = ExtractedContent.from_processing(
-            sample_video, sample_captions, tmp_path
+        content = extract_content(
+            video_url="http://example.com",
+            video_title="Test",
+            video_id="test",
+            image_dir=tmp_path,
+            caption_texts=["caption"],
+            duplicate_indices=set(),
         )
 
-        assert content.images == []
-        assert len(content.captions) == 3
+        assert content.slides == []
 
 
 class TestExtractedContentSerialization:
-    def test_to_json_produces_valid_json(
-        self, tmp_path: Path, sample_video: Video, sample_captions: list[Caption]
-    ) -> None:
-        _create_test_images(tmp_path)
-        content = ExtractedContent.from_processing(
-            sample_video, sample_captions, tmp_path
+    def test_to_dict_produces_correct_structure(self) -> None:
+        content = ExtractedContent(
+            video=VideoInfo(url="http://test", title="Test", id="t1"),
+            slides=[
+                SlideData(
+                    index=0,
+                    image_base64="abc123",
+                    timestamp_seconds=0,
+                    caption_text="Hello",
+                    is_duplicate=False,
+                )
+            ],
+            seconds_per_shot=30,
         )
 
-        json_str = content.to_json()
-        parsed = json.loads(json_str)
+        d = content.to_dict()
 
-        assert parsed["schema_version"] == CONTENT_SCHEMA_VERSION
-        assert parsed["video_url"] == sample_video.url
-        assert parsed["video_title"] == sample_video.title
-        assert len(parsed["captions"]) == 3
-        assert len(parsed["images"]) == 3
+        assert d["schema_version"] == SCHEMA_VERSION
+        assert d["video"]["url"] == "http://test"
+        assert d["video"]["title"] == "Test"
+        assert d["video"]["id"] == "t1"
+        assert len(d["slides"]) == 1
+        assert d["slides"][0]["index"] == 0
+        assert d["slides"][0]["caption_text"] == "Hello"
+        assert d["config"]["seconds_per_shot"] == 30
 
-    def test_save_and_load_roundtrip(
-        self, tmp_path: Path, sample_video: Video, sample_captions: list[Caption]
-    ) -> None:
-        # Create images in a subdirectory
-        img_dir = tmp_path / "images"
-        img_dir.mkdir()
-        _create_test_images(img_dir)
-
-        content = ExtractedContent.from_processing(
-            sample_video, sample_captions, img_dir
+    def test_save_and_load_roundtrip(self, tmp_path: Path) -> None:
+        original = ExtractedContent(
+            video=VideoInfo(url="http://test", title="Test Video", id="vid123"),
+            slides=[
+                SlideData(
+                    index=0,
+                    image_base64="base64data",
+                    timestamp_seconds=0,
+                    caption_text="Caption",
+                    is_duplicate=False,
+                ),
+                SlideData(
+                    index=1,
+                    image_base64="moredata",
+                    timestamp_seconds=30,
+                    caption_text="More",
+                    is_duplicate=True,
+                ),
+            ],
+            seconds_per_shot=30,
         )
 
-        # Save to file
         json_path = tmp_path / "content.json"
-        content.save(json_path)
+        original.save(json_path)
         assert json_path.exists()
 
-        # Load from file
         loaded = ExtractedContent.load(json_path)
 
-        assert loaded.schema_version == content.schema_version
-        assert loaded.video_url == content.video_url
-        assert loaded.video_title == content.video_title
-        assert loaded.video_id == content.video_id
-        assert loaded.captions == content.captions
-        assert len(loaded.images) == len(content.images)
-        for orig, loaded_img in zip(content.images, loaded.images):
-            assert orig["index"] == loaded_img["index"]
-            assert orig["data_base64"] == loaded_img["data_base64"]
+        assert loaded.video.url == original.video.url
+        assert loaded.video.title == original.video.title
+        assert loaded.video.id == original.video.id
+        assert len(loaded.slides) == len(original.slides)
+        for orig, load in zip(original.slides, loaded.slides):
+            assert load.index == orig.index
+            assert load.image_base64 == orig.image_base64
+            assert load.caption_text == orig.caption_text
+            assert load.is_duplicate == orig.is_duplicate
 
     def test_load_rejects_unsupported_schema_version(self, tmp_path: Path) -> None:
-        json_path = tmp_path / "future_content.json"
+        json_path = tmp_path / "future.json"
         json_path.write_text(
             json.dumps(
                 {
-                    "schema_version": CONTENT_SCHEMA_VERSION + 1,
-                    "video_url": "http://test",
-                    "video_title": "Test",
-                    "video_id": "test",
-                    "captions": [],
-                    "images": [],
-                    "seconds_per_shot": 30,
+                    "schema_version": SCHEMA_VERSION + 1,
+                    "video": {"url": "x", "title": "x", "id": "x"},
+                    "slides": [],
+                    "config": {},
                 }
             )
         )
 
-        with pytest.raises(ValueError, match="Unsupported schema version"):
+        with pytest.raises(ValueError, match="not supported"):
             ExtractedContent.load(json_path)
 
 
-class TestExtractedContentHelpers:
-    def test_get_video_reconstructs_video_object(
-        self, tmp_path: Path, sample_video: Video, sample_captions: list[Caption]
-    ) -> None:
-        _create_test_images(tmp_path)
-        content = ExtractedContent.from_processing(
-            sample_video, sample_captions, tmp_path
+class TestSlideData:
+    def test_frozen_dataclass(self) -> None:
+        slide = SlideData(
+            index=0,
+            image_base64="data",
+            timestamp_seconds=0,
+            caption_text="text",
+            is_duplicate=False,
         )
+        # Should not be modifiable
+        with pytest.raises(AttributeError):
+            slide.index = 1  # type: ignore
 
-        video = content.get_video()
 
-        assert video.url == sample_video.url
-        assert video.title == sample_video.title
-        assert video.video_id == sample_video.video_id
-
-    def test_get_captions_reconstructs_caption_objects(
-        self, tmp_path: Path, sample_video: Video, sample_captions: list[Caption]
-    ) -> None:
-        _create_test_images(tmp_path)
-        content = ExtractedContent.from_processing(
-            sample_video, sample_captions, tmp_path
-        )
-
-        captions = content.get_captions()
-
-        assert len(captions) == len(sample_captions)
-        for orig, loaded in zip(sample_captions, captions):
-            assert orig.start == loaded.start
-            assert orig.end == loaded.end
-            assert orig.text == loaded.text
-
-    def test_get_image_data_returns_decoded_bytes(
-        self, tmp_path: Path, sample_video: Video, sample_captions: list[Caption]
-    ) -> None:
-        _create_test_images(tmp_path, count=1)
-        content = ExtractedContent.from_processing(
-            sample_video, sample_captions, tmp_path
-        )
-
-        data = content.get_image_data(0)
-
-        assert data is not None
-        assert len(data) > 0
-        # Verify it's valid JPEG by checking magic bytes
-        assert data[:2] == b"\xff\xd8"
-
-    def test_get_image_data_returns_none_for_missing(
-        self, tmp_path: Path, sample_video: Video, sample_captions: list[Caption]
-    ) -> None:
-        _create_test_images(tmp_path, count=1)
-        content = ExtractedContent.from_processing(
-            sample_video, sample_captions, tmp_path
-        )
-
-        data = content.get_image_data(999)
-
-        assert data is None
-
-    def test_get_image_indices_returns_sorted_list(
-        self, tmp_path: Path, sample_video: Video, sample_captions: list[Caption]
-    ) -> None:
-        _create_test_images(tmp_path, count=3)
-        content = ExtractedContent.from_processing(
-            sample_video, sample_captions, tmp_path
-        )
-
-        indices = content.get_image_indices()
-
-        assert indices == [0, 1, 2]
+class TestVideoInfo:
+    def test_frozen_dataclass(self) -> None:
+        video = VideoInfo(url="http://x", title="X", id="x")
+        with pytest.raises(AttributeError):
+            video.url = "http://y"  # type: ignore

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,0 +1,140 @@
+"""Tests for glancer-extract CLI."""
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from PIL import Image
+
+from glancer.extract import (
+    Caption,
+    Video,
+    extract,
+    find_duplicates,
+    get_caption_texts,
+    parse_captions,
+)
+
+
+def _create_test_image(path: Path, color: tuple[int, int, int]) -> None:
+    """Create a simple test JPEG image."""
+    img = Image.new("RGB", (64, 64), color=color)
+    img.save(path, format="JPEG")
+
+
+class TestParseCaptions:
+    def test_parses_srt_file(self, tmp_path: Path) -> None:
+        srt_content = """1
+00:00:00,000 --> 00:00:05,000
+Hello world
+
+2
+00:00:05,000 --> 00:00:10,000
+Second caption
+"""
+        srt_path = tmp_path / "test.srt"
+        srt_path.write_text(srt_content)
+
+        captions = parse_captions(srt_path)
+
+        assert len(captions) == 2
+        assert captions[0].text == "Hello world"
+        assert captions[0].start == 0.0
+        assert captions[0].end == 5.0
+        assert captions[1].text == "Second caption"
+
+
+class TestGetCaptionTexts:
+    def test_combines_captions_per_shot(self) -> None:
+        # Captions spanning 60+ seconds to create 2 shots
+        captions = [
+            Caption(start=0.0, end=5.0, text="First"),
+            Caption(start=25.0, end=30.0, text="Second"),
+            Caption(start=35.0, end=65.0, text="Third"),
+        ]
+
+        texts = get_caption_texts(captions)
+
+        # floor(65/30) = 2 shots
+        assert len(texts) == 2
+        assert "First" in texts[0]
+        assert "Second" in texts[0]
+        assert "Third" in texts[1]
+
+    def test_empty_captions_returns_empty(self) -> None:
+        assert get_caption_texts([]) == []
+
+
+def _create_patterned_image(path: Path, pattern: str) -> None:
+    """Create an image with a distinct pattern for unique perceptual hash."""
+    img = Image.new("RGB", (64, 64))
+    pixels = img.load()
+    for y in range(64):
+        for x in range(64):
+            if pattern == "checkerboard":
+                val = 255 if (x // 8 + y // 8) % 2 == 0 else 0
+            elif pattern == "vertical_stripes":
+                val = 255 if (x // 8) % 2 == 0 else 0
+            elif pattern == "diagonal":
+                val = 255 if x > y else 0
+            else:
+                val = 128
+            pixels[x, y] = (val, val, val)
+    img.save(path, format="JPEG")
+
+
+class TestFindDuplicates:
+    def test_marks_identical_images_as_duplicates(self, tmp_path: Path) -> None:
+        # Create identical images (solid color has same dhash)
+        for i in range(3):
+            _create_test_image(tmp_path / f"glancer-img{i:04d}.jpg", (100, 100, 100))
+
+        duplicates = find_duplicates(tmp_path)
+
+        # First image is not a duplicate, subsequent ones are
+        assert 0 not in duplicates
+        assert 1 in duplicates
+        assert 2 in duplicates
+
+    def test_different_patterns_not_duplicates(self, tmp_path: Path) -> None:
+        # Create images with distinct patterns for different dhash values
+        _create_patterned_image(tmp_path / "glancer-img0000.jpg", "checkerboard")
+        _create_patterned_image(tmp_path / "glancer-img0001.jpg", "vertical_stripes")
+        _create_patterned_image(tmp_path / "glancer-img0002.jpg", "diagonal")
+
+        duplicates = find_duplicates(tmp_path)
+
+        assert len(duplicates) == 0
+
+
+class TestExtract:
+    def test_creates_extracted_content(self, tmp_path: Path) -> None:
+        # Create test images
+        for i in range(2):
+            _create_test_image(tmp_path / f"glancer-img{i:04d}.jpg", (100, 100, 100))
+
+        video = Video(url="http://example.com", title="Test", video_id="test123")
+        caption_texts = ["First caption", "Second caption"]
+        duplicates = {1}
+
+        content = extract(video, tmp_path, caption_texts, duplicates)
+
+        assert content.video.url == "http://example.com"
+        assert content.video.title == "Test"
+        assert content.video.id == "test123"
+        assert len(content.slides) == 2
+        assert content.slides[0].caption_text == "First caption"
+        assert content.slides[0].is_duplicate is False
+        assert content.slides[1].is_duplicate is True
+
+    def test_encodes_images_as_base64(self, tmp_path: Path) -> None:
+        _create_test_image(tmp_path / "glancer-img0000.jpg", (100, 100, 100))
+
+        video = Video(url="http://example.com", title="Test", video_id="test")
+        content = extract(video, tmp_path, [""], set())
+
+        # Verify base64 is valid JPEG
+        decoded = base64.b64decode(content.slides[0].image_base64)
+        assert decoded[:2] == b"\xff\xd8"  # JPEG magic bytes

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,0 +1,92 @@
+"""Tests for glancer-render CLI."""
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from PIL import Image
+
+from glancer.render import (
+    _escape_typst,
+    _format_time,
+    render_html,
+)
+from glancer.schema import ExtractedContent, SlideData, VideoMeta
+
+
+def _create_base64_jpeg() -> str:
+    """Create a minimal base64-encoded JPEG."""
+    from io import BytesIO
+
+    img = Image.new("RGB", (64, 64), color=(100, 100, 100))
+    buffer = BytesIO()
+    img.save(buffer, format="JPEG")
+    return base64.b64encode(buffer.getvalue()).decode("ascii")
+
+
+class TestRenderHtml:
+    def test_produces_valid_html(self) -> None:
+        content = ExtractedContent(
+            video=VideoMeta(url="http://example.com", title="Test Video", id="test"),
+            slides=[
+                SlideData(
+                    index=0,
+                    image_base64=_create_base64_jpeg(),
+                    timestamp_seconds=0,
+                    caption_text="First caption",
+                    is_duplicate=False,
+                ),
+            ],
+            seconds_per_shot=30,
+        )
+
+        html = render_html(content)
+
+        assert "<!DOCTYPE html>" in html
+        assert "Test Video" in html
+        assert "First caption" in html
+        assert "data:image/jpeg;base64" in html
+        assert "slide-block" in html
+
+    def test_marks_duplicates_with_class(self) -> None:
+        content = ExtractedContent(
+            video=VideoMeta(url="http://example.com", title="Test", id="test"),
+            slides=[
+                SlideData(
+                    index=0,
+                    image_base64=_create_base64_jpeg(),
+                    timestamp_seconds=0,
+                    caption_text="",
+                    is_duplicate=True,
+                ),
+            ],
+            seconds_per_shot=30,
+        )
+
+        html = render_html(content)
+
+        assert "slide-block duplicate" in html
+
+
+class TestFormatTime:
+    def test_formats_seconds_only(self) -> None:
+        assert _format_time(45) == "0:45"
+
+    def test_formats_minutes_and_seconds(self) -> None:
+        assert _format_time(125) == "2:05"
+
+    def test_formats_hours(self) -> None:
+        assert _format_time(3665) == "1:01:05"
+
+
+class TestEscapeTypst:
+    def test_escapes_special_chars(self) -> None:
+        assert _escape_typst("#$*_<>@[]") == "\\#\\$\\*\\_\\<\\>\\@\\[\\]"
+
+    def test_escapes_backslash(self) -> None:
+        assert _escape_typst("\\") == "\\\\"
+
+    def test_leaves_normal_text(self) -> None:
+        assert _escape_typst("Hello world") == "Hello world"

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,116 @@
+"""Tests for the shared JSON schema module."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from glancer.schema import (
+    SCHEMA_VERSION,
+    ExtractedContent,
+    SlideData,
+    VideoMeta,
+)
+
+
+class TestVideoMeta:
+    def test_frozen_dataclass(self) -> None:
+        video = VideoMeta(url="http://x", title="X", id="x")
+        with pytest.raises(AttributeError):
+            video.url = "http://y"  # type: ignore
+
+
+class TestSlideData:
+    def test_frozen_dataclass(self) -> None:
+        slide = SlideData(
+            index=0,
+            image_base64="data",
+            timestamp_seconds=0,
+            caption_text="text",
+            is_duplicate=False,
+        )
+        with pytest.raises(AttributeError):
+            slide.index = 1  # type: ignore
+
+
+class TestExtractedContent:
+    def test_to_dict_produces_correct_structure(self) -> None:
+        content = ExtractedContent(
+            video=VideoMeta(url="http://test", title="Test", id="t1"),
+            slides=[
+                SlideData(
+                    index=0,
+                    image_base64="abc123",
+                    timestamp_seconds=0,
+                    caption_text="Hello",
+                    is_duplicate=False,
+                )
+            ],
+            seconds_per_shot=30,
+        )
+
+        d = content.to_dict()
+
+        assert d["schema_version"] == SCHEMA_VERSION
+        assert d["video"]["url"] == "http://test"
+        assert d["video"]["title"] == "Test"
+        assert d["video"]["id"] == "t1"
+        assert len(d["slides"]) == 1
+        assert d["slides"][0]["index"] == 0
+        assert d["slides"][0]["caption_text"] == "Hello"
+        assert d["config"]["seconds_per_shot"] == 30
+
+    def test_save_and_load_roundtrip(self, tmp_path: Path) -> None:
+        original = ExtractedContent(
+            video=VideoMeta(url="http://test", title="Test Video", id="vid123"),
+            slides=[
+                SlideData(
+                    index=0,
+                    image_base64="base64data",
+                    timestamp_seconds=0,
+                    caption_text="Caption",
+                    is_duplicate=False,
+                ),
+                SlideData(
+                    index=1,
+                    image_base64="moredata",
+                    timestamp_seconds=30,
+                    caption_text="More",
+                    is_duplicate=True,
+                ),
+            ],
+            seconds_per_shot=30,
+        )
+
+        json_path = tmp_path / "content.json"
+        original.save(json_path)
+        assert json_path.exists()
+
+        loaded = ExtractedContent.load(json_path)
+
+        assert loaded.video.url == original.video.url
+        assert loaded.video.title == original.video.title
+        assert loaded.video.id == original.video.id
+        assert len(loaded.slides) == len(original.slides)
+        for orig, load in zip(original.slides, loaded.slides):
+            assert load.index == orig.index
+            assert load.image_base64 == orig.image_base64
+            assert load.caption_text == orig.caption_text
+            assert load.is_duplicate == orig.is_duplicate
+
+    def test_load_rejects_unsupported_schema_version(self, tmp_path: Path) -> None:
+        json_path = tmp_path / "future.json"
+        json_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": SCHEMA_VERSION + 1,
+                    "video": {"url": "x", "title": "x", "id": "x"},
+                    "slides": [],
+                    "config": {},
+                }
+            )
+        )
+
+        with pytest.raises(ValueError, match="not supported"):
+            ExtractedContent.load(json_path)


### PR DESCRIPTION
Add two-phase workflow for video processing:

Phase 1 (Content Extraction):
- New --extract-json flag outputs all video content to JSON
- ExtractedContent dataclass holds base64-encoded images, captions, and video metadata in a serializable format
- JSON schema includes version for forward compatibility

Phase 2 (Artifact Generation):
- New --from-json flag generates HTML/PDF from existing JSON
- convert_to_html_from_content() and convert_to_pdf_from_content() work directly with ExtractedContent without re-processing
- find_similar_shots_from_data() for duplicate detection from base64

Benefits:
- Cache expensive extraction for repeated styling experiments
- Share extracted content across different output formats
- Speed up development of new output templates